### PR TITLE
boulder/moss: Support shell completions generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "clap",
+ "clap_complete",
  "config",
  "container",
  "derive_more",
@@ -272,6 +273,15 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd79504325bf38b10165b02e89b4347300f855f273c4cb30c4a3209e6583275e"
+dependencies = [
+ "clap",
 ]
 
 [[package]]
@@ -1163,6 +1173,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
+ "clap_complete",
  "config",
  "container",
  "dag",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,11 @@ edition = "2021"
 bytes = "1.5.0"
 chrono = "0.4.34"
 clap = { version = "4.5.1", features = ["derive", "string"] }
+clap_complete = "4.5.2"
 crossterm = "0.27.0"
 derive_more = "0.99"
 dialoguer = "0.11.0"
-diesel = { version = "2.1.4", features = ["sqlite","returning_clauses_for_sqlite_3_35"] }
+diesel = { version = "2.1.4", features = ["sqlite", "returning_clauses_for_sqlite_3_35"] }
 diesel_migrations = "2.1.0"
 dirs = "5.0"
 elf = "0.7.4"
@@ -48,7 +49,7 @@ tokio-stream = { version = "0.1.14", features = ["time"] }
 tokio-util = { version = "0.7.9", features = ["io"] }
 url = { version = "2.5.0", features = ["serde"] }
 xxhash-rust = { version = "0.8.10", features = ["xxh3"] }
-zstd = { version = "0.12.4", features = [ "zstdmt" ] }
+zstd = { version = "0.12.4", features = ["zstdmt"] }
 
 [profile.release]
 lto = 'thin'

--- a/boulder/Cargo.toml
+++ b/boulder/Cargo.toml
@@ -16,6 +16,7 @@ yaml = { path = "../crates/yaml" }
 
 chrono.workspace = true
 clap.workspace = true
+clap_complete.workspace = true
 derive_more.workspace = true
 dirs.workspace = true
 elf.workspace = true

--- a/boulder/src/cli.rs
+++ b/boulder/src/cli.rs
@@ -4,11 +4,12 @@
 use std::path::PathBuf;
 
 use boulder::{env, Env};
-use clap::{Args, Parser};
+use clap::{Args, CommandFactory, Parser};
 use thiserror::Error;
 
 mod build;
 mod chroot;
+mod completions;
 mod profile;
 mod recipe;
 
@@ -37,6 +38,7 @@ pub struct Global {
 pub enum Subcommand {
     Build(build::Command),
     Chroot(chroot::Command),
+    Completions(completions::Command),
     Profile(profile::Command),
     Recipe(recipe::Command),
 }
@@ -50,6 +52,7 @@ pub fn process() -> Result<(), Error> {
     match subcommand {
         Subcommand::Build(command) => build::handle(command, env)?,
         Subcommand::Chroot(command) => chroot::handle(command, env)?,
+        Subcommand::Completions(command) => completions::handle(command, Command::command()),
         Subcommand::Profile(command) => profile::handle(command, env)?,
         Subcommand::Recipe(command) => recipe::handle(command)?,
     }

--- a/boulder/src/cli/completions.rs
+++ b/boulder/src/cli/completions.rs
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: Copyright © 2020-2024 Serpent OS Developers
+//
+// SPDX-License-Identifier: MPL-2.0
+
+use std::io;
+
+use clap::Parser;
+use clap_complete::{generate, Generator, Shell};
+
+#[derive(Debug, Parser)]
+#[command(about = "Generate shell completions")]
+pub struct Command {
+    #[arg(help = "Shell to generate completions for")]
+    shell: Shell,
+}
+
+pub fn handle(command: Command, cli: clap::Command) {
+    let Command { shell } = command;
+
+    let mut cmd = cli;
+    completions(shell, &mut cmd);
+}
+
+fn completions<G: Generator>(gen: G, cmd: &mut clap::Command) {
+    generate(gen, cmd, cmd.get_name().to_string(), &mut io::stdout());
+}

--- a/moss/Cargo.toml
+++ b/moss/Cargo.toml
@@ -13,6 +13,7 @@ vfs = { path = "../crates/vfs" }
 bytes.workspace = true
 chrono.workspace = true
 clap.workspace = true
+clap_complete.workspace = true
 derive_more.workspace = true
 diesel.workspace = true
 diesel_migrations.workspace = true

--- a/moss/src/cli/completions.rs
+++ b/moss/src/cli/completions.rs
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: Copyright © 2020-2024 Serpent OS Developers
+//
+// SPDX-License-Identifier: MPL-2.0
+
+use std::io;
+
+use clap::{arg, ArgMatches};
+use clap_complete::{generate, Generator, Shell};
+
+pub fn command() -> clap::Command {
+    clap::Command::new("completions")
+        .about("Generate shell completions")
+        .arg(arg!(<SHELL> ... "Shell to generate completions for").value_parser(clap::value_parser!(Shell)))
+}
+
+pub fn handle(args: &ArgMatches, cli: clap::Command) {
+    let shell = *args.get_one::<Shell>("SHELL").unwrap();
+
+    let mut cmd = cli;
+    completions(shell, &mut cmd);
+}
+
+fn completions<G: Generator>(gen: G, cmd: &mut clap::Command) {
+    generate(gen, cmd, cmd.get_name().to_string(), &mut io::stdout());
+}

--- a/moss/src/cli/mod.rs
+++ b/moss/src/cli/mod.rs
@@ -8,6 +8,7 @@ use clap::{Arg, ArgAction, Command};
 use moss::{installation, runtime, Installation};
 use thiserror::Error;
 
+mod completions;
 mod extract;
 mod index;
 mod info;
@@ -58,6 +59,7 @@ fn command() -> Command {
                 .action(ArgAction::SetTrue),
         )
         .arg_required_else_help(true)
+        .subcommand(completions::command())
         .subcommand(extract::command())
         .subcommand(index::command())
         .subcommand(info::command())
@@ -94,6 +96,10 @@ pub fn process() -> Result<(), Error> {
     }
 
     match matches.subcommand() {
+        Some(("completions", args)) => {
+            completions::handle(args, command());
+            Ok(())
+        }
         Some(("extract", args)) => extract::handle(args).map_err(Error::Extract),
         Some(("index", args)) => index::handle(args).map_err(Error::Index),
         Some(("info", args)) => info::handle(args, installation).map_err(Error::Info),


### PR DESCRIPTION
This wires up clap_complete so that the `completions` subcommand of boulder and moss will now automatically generate shell completions when provided a shell as the single argument.

The second commit replaces the alias implementation in moss with one that works better with how Clap works with shell completions. Now commands like `moss ur` correctly show further completions as though the user had used `moss repo update`

Closes serpent-os/moss#220