### PR TITLE
boulder/data: Ensure split-machine-functions are disabled in bolt flags

### DIFF
--- a/boulder/data/macros/actions/pgo.yaml
+++ b/boulder/data/macros/actions/pgo.yaml
@@ -37,7 +37,7 @@ actions:
         description: Apply bolt profile
         command: |
             boptim(){
-                llvm-bolt ${1}.orig -o ${1}.bolt -data=%(pgo_dir)/$(basename ${1}).fdata -reorder-blocks=cache+ -reorder-functions=hfsort+ -split-functions=3 -split-all-cold -split-eh -dyno-stats -icf=1 -use-gnu-stack ${2} ${3} ${4}
+                llvm-bolt ${1}.orig -o ${1}.bolt -data=%(pgo_dir)/$(basename ${1}).fdata -reorder-blocks=ext-tsp -reorder-functions=hfsort+ -split-functions -split-strategy=cdsplit -plt=all -peepholes=all -split-eh -dyno-stats -icf=1 -use-gnu-stack -use-old-text -update-debug-sections ${2} ${3} ${4}
                 cp ${1}.bolt ${1}
             }
             boptim

--- a/boulder/data/macros/arch/base.yaml
+++ b/boulder/data/macros/arch/base.yaml
@@ -449,6 +449,8 @@ flags               :
             cxx       : "-fno-reorder-blocks-and-partition​"
             ld        : "-Wl,-q"
         llvm:
+            c         : "-fno-split-machine-functions"
+            cxx       : "-fno-split-machine-functions"
             ld        : "-Wl,-q"
 
     # Toggle -fcommon (OFF)


### PR DESCRIPTION
split-machine-functions is an optional flag for PGO optimize builds that uses the profile data to split hot/cold/unlikely .text sections.

Although disabled by default, BOLT does it's own version of splitting hot/cold .text which split-machine-functions gets in the way of.