### PR TITLE
Run boulder inside docker fixes

### DIFF
--- a/boulder/src/cli/build.rs
+++ b/boulder/src/cli/build.rs
@@ -98,7 +98,7 @@ pub fn handle(command: Command, env: Env) -> Result<(), Error> {
         "boulder".into(),
         format!("Build in-progress: {}", pkg_name),
         "block".into(),
-    )?;
+    );
 
     // Build & package from within container
     container::exec::<Error>(paths, networking, || {
@@ -143,6 +143,4 @@ pub enum Error {
     Container(#[from] container::Error),
     #[error("setting thread priority")]
     Priority(#[from] thread_priority::Error),
-    #[error("failed to connect to dbus")]
-    Zbus(#[from] moss::signal::Error),
 }

--- a/crates/container/src/lib.rs
+++ b/crates/container/src/lib.rs
@@ -379,9 +379,17 @@ pub fn set_term_fg(pgid: Pid) -> Result<(), nix::Error> {
         )?
     };
     // Set term fg to pid
-    tcsetpgrp(io::stdin().as_raw_fd(), pgid)?;
+    let res = tcsetpgrp(io::stdin().as_raw_fd(), pgid);
     // Set up old handler
     unsafe { sigaction(Signal::SIGTTOU, &prev_handler)? };
+
+    match res {
+        Ok(_) => {}
+        // Ignore ENOTTY error
+        Err(nix::Error::ENOTTY) => {}
+        Err(e) => return Err(e),
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
Fixes needed to run boulder inside docker:

- systemd is probably not pid 1 and we can't rely on inhibit working (don't make this a fatal error)
- We have some logic around term fg capturing to recapture ctrl-c functionality after invoking bash within user namespace. This fails when we don't have a controlling terminal. This can be ignored in those cases and shouldn't be fatal.