### PR TITLE
boulder: Add `%gtk_update_icon_cache` action macro

### DIFF
--- a/boulder/data/macros/actions/misc.yaml
+++ b/boulder/data/macros/actions/misc.yaml
@@ -1,5 +1,16 @@
 actions:
 
+    - gtk_update_icon_cache:
+        description: Pregenerate icon cache at build time
+        example: |
+            %gtk_update_icon_cache
+        command: |
+            for i in %(installroot)%(datadir)/icons/*/; do
+                gtk-update-icon-cache -f $i
+            done
+        dependencies:
+            - binary(gtk-update-icon-cache)
+
     - install_bin:
         description: Install files to %(bindir)
         example: |


### PR DESCRIPTION
Most icon themes benefit from having their icon cache pre-generated at build time.

The invocation for doing so follows a distinct pattern, hence this macro could perhaps be gainfully used as a simpler substitution.