### PR TITLE
Replace thiserror with SNAFU

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,8 +641,8 @@ version = "0.24.7"
 dependencies = [
  "fs-err",
  "nix 0.27.1",
+ "snafu",
  "strum",
- "thiserror 2.0.3",
 ]
 
 [[package]]
@@ -2598,6 +2598,27 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "snafu"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "223891c85e2a29c3fe8fb900c1fae5e69c2e42415e3177752e8718475efa5019"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "socket2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ serde_derive = "1.0.204"
 serde_json = "1.0.120"
 serde_yaml = "0.9.34"
 sha2 = "0.10.8"
+snafu = "0.8.5"
 strum = { version = "0.26.3", features = ["derive"] }
 thiserror = "2.0.3"
 thread-priority = "1.1.0"

--- a/boulder/src/container.rs
+++ b/boulder/src/container.rs
@@ -9,14 +9,14 @@ use crate::Paths;
 
 pub fn exec<E>(paths: &Paths, networking: bool, f: impl FnMut() -> Result<(), E>) -> Result<(), Error>
 where
-    E: std::error::Error + 'static,
+    E: std::error::Error + Send + Sync + 'static,
 {
     run(paths, networking, f)
 }
 
 fn run<E>(paths: &Paths, networking: bool, f: impl FnMut() -> Result<(), E>) -> Result<(), Error>
 where
-    E: std::error::Error + 'static,
+    E: std::error::Error + Send + Sync + 'static,
 {
     let rootfs = paths.rootfs().host;
     let artefacts = paths.artefacts();

--- a/boulder/src/draft/build.rs
+++ b/boulder/src/draft/build.rs
@@ -14,7 +14,7 @@ mod cmake;
 mod meson;
 mod python;
 
-pub type Error = Box<dyn std::error::Error>;
+pub type Error = Box<dyn std::error::Error + Send + Sync>;
 
 /// A build system
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, strum::Display)]

--- a/boulder/src/package/analysis.rs
+++ b/boulder/src/package/analysis.rs
@@ -18,7 +18,7 @@ use super::collect::{Collector, PathInfo};
 
 mod handler;
 
-pub type BoxError = Box<dyn std::error::Error>;
+pub type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
 pub struct Chain<'a> {
     handlers: Vec<Box<dyn Handler>>,

--- a/crates/container/Cargo.toml
+++ b/crates/container/Cargo.toml
@@ -9,5 +9,5 @@ rust-version.workspace = true
 [dependencies]
 fs-err.workspace = true
 nix.workspace = true
+snafu.workspace = true
 strum.workspace = true
-thiserror.workspace = true

--- a/crates/container/src/lib.rs
+++ b/crates/container/src/lib.rs
@@ -19,7 +19,7 @@ use nix::sys::signalfd::SigSet;
 use nix::sys::stat::{umask, Mode};
 use nix::sys::wait::{waitpid, WaitStatus};
 use nix::unistd::{close, pipe, pivot_root, read, sethostname, tcsetpgrp, write, Pid, Uid};
-use thiserror::Error;
+use snafu::{ResultExt, Snafu};
 
 use self::idmap::idmap;
 
@@ -120,7 +120,7 @@ impl Container {
         let rootless = !Uid::effective().is_root();
 
         // Pipe to synchronize parent & child
-        let sync = pipe()?;
+        let sync = pipe().context(NixSnafu)?;
 
         let mut flags =
             CloneFlags::CLONE_NEWNS | CloneFlags::CLONE_NEWPID | CloneFlags::CLONE_NEWIPC | CloneFlags::CLONE_NEWUTS;
@@ -158,27 +158,28 @@ impl Container {
                 &mut *addr_of_mut!(STACK),
                 flags,
                 Some(SIGCHLD),
-            )?
+            )
+            .context(NixSnafu)?
         };
 
         // Update uid / gid map to map current user to root in container
         if rootless {
-            idmap(pid)?;
+            idmap(pid).context(IdmapSnafu)?;
         }
 
         // Allow child to continue
-        write(sync.1, &[Message::Continue as u8])?;
+        write(sync.1, &[Message::Continue as u8]).context(NixSnafu)?;
         // Write no longer needed
-        close(sync.1)?;
+        close(sync.1).context(NixSnafu)?;
 
         if self.ignore_host_sigint {
-            ignore_sigint()?;
+            ignore_sigint().context(NixSnafu)?;
         }
 
-        let status = waitpid(pid, None)?;
+        let status = waitpid(pid, None).context(NixSnafu)?;
 
         if self.ignore_host_sigint {
-            default_sigint()?;
+            default_sigint().context(NixSnafu)?;
         }
 
         match status {
@@ -188,7 +189,7 @@ impl Container {
                 let mut buffer = [0u8; 1024];
 
                 loop {
-                    let len = read(sync.0, &mut buffer)?;
+                    let len = read(sync.0, &mut buffer).context(NixSnafu)?;
 
                     if len == 0 {
                         break;
@@ -197,9 +198,9 @@ impl Container {
                     error.push_str(String::from_utf8_lossy(&buffer[..len]).as_ref());
                 }
 
-                Err(Error::Failure(error))
+                Err(Error::Failure { message: error })
             }
-            WaitStatus::Signaled(_, signal, _) => Err(Error::Signaled(signal)),
+            WaitStatus::Signaled(_, signal, _) => Err(Error::Signaled { signal }),
             WaitStatus::Stopped(_, _)
             | WaitStatus::PtraceEvent(_, _, _)
             | WaitStatus::PtraceSyscall(_)
@@ -215,19 +216,19 @@ where
     E: std::error::Error + Send + Sync + 'static,
 {
     // Ensure process is cleaned up if parent dies
-    set_pdeathsig(Signal::SIGKILL).map_err(ContainerError::SetPDeathSig)?;
+    set_pdeathsig(Signal::SIGKILL).context(SetPDeathSigSnafu)?;
 
     // Wait for continue message
     let mut message = [0u8; 1];
-    read(sync.0, &mut message).map_err(ContainerError::ReadContinueMsg)?;
+    read(sync.0, &mut message).context(ReadContinueMsgSnafu)?;
     assert_eq!(message[0], Message::Continue as u8);
 
     // Close unused read end
-    close(sync.0).map_err(ContainerError::CloseReadFd)?;
+    close(sync.0).context(CloseReadFdSnafu)?;
 
     setup(container)?;
 
-    f().map_err(|e| ContainerError::Run(Box::new(e)))
+    f().boxed().context(RunSnafu)
 }
 
 /// Setup the container
@@ -245,7 +246,7 @@ fn setup(container: &Container) -> Result<(), ContainerError> {
     }
 
     if let Some(hostname) = &container.hostname {
-        sethostname(hostname).map_err(ContainerError::SetHostname)?;
+        sethostname(hostname).context(SetHostnameSnafu)?;
     }
 
     if let Some(dir) = &container.work_dir {
@@ -265,7 +266,7 @@ fn pivot(root: &Path, binds: &[Bind]) -> Result<(), ContainerError> {
     add_mount(Some(root), root, None, MsFlags::MS_BIND)?;
 
     for bind in binds {
-        let source = bind.source.fs_err_canonicalize()?;
+        let source = bind.source.fs_err_canonicalize().context(FsErrSnafu)?;
         let target = root.join(bind.target.strip_prefix("/").unwrap_or(&bind.target));
 
         add_mount(Some(&source), &target, None, MsFlags::MS_BIND)?;
@@ -282,7 +283,7 @@ fn pivot(root: &Path, binds: &[Bind]) -> Result<(), ContainerError> {
     }
 
     ensure_directory(&old_root)?;
-    pivot_root(root, &old_root).map_err(ContainerError::PivotRoot)?;
+    pivot_root(root, &old_root).context(PivotRootSnafu)?;
 
     set_current_dir("/")?;
 
@@ -301,37 +302,40 @@ fn pivot(root: &Path, binds: &[Bind]) -> Result<(), ContainerError> {
         MsFlags::MS_BIND | MsFlags::MS_REC | MsFlags::MS_SLAVE,
     )?;
 
-    umount2(OLD_PATH, MntFlags::MNT_DETACH).map_err(ContainerError::UnmountOldRoot)?;
-    remove_dir(OLD_PATH)?;
+    umount2(OLD_PATH, MntFlags::MNT_DETACH).context(UnmountOldRootSnafu)?;
+    remove_dir(OLD_PATH).context(FsErrSnafu)?;
 
     Ok(())
 }
 
 fn setup_root_user() -> Result<(), ContainerError> {
     ensure_directory("/etc")?;
-    fs::write("/etc/passwd", "root:x:0:0:root::/bin/bash")?;
-    fs::write("/etc/group", "root:x:0:")?;
+    fs::write("/etc/passwd", "root:x:0:0:root::/bin/bash").context(FsErrSnafu)?;
+    fs::write("/etc/group", "root:x:0:").context(FsErrSnafu)?;
     umask(Mode::S_IWGRP | Mode::S_IWOTH);
     Ok(())
 }
 
 fn setup_networking(root: &Path) -> Result<(), ContainerError> {
     ensure_directory(root.join("etc"))?;
-    copy("/etc/resolv.conf", root.join("etc/resolv.conf"))?;
-    copy("/etc/protocols", root.join("etc/protocols"))?;
+    copy("/etc/resolv.conf", root.join("etc/resolv.conf")).context(FsErrSnafu)?;
+    copy("/etc/protocols", root.join("etc/protocols")).context(FsErrSnafu)?;
     Ok(())
 }
 
 fn setup_localhost() -> Result<(), ContainerError> {
     // TODO: maybe it's better to hunt down the API to do this instead?
-    Command::new("ip").args(["link", "set", "lo", "up"]).output()?;
+    Command::new("ip")
+        .args(["link", "set", "lo", "up"])
+        .output()
+        .context(SetupLocalhostSnafu)?;
     Ok(())
 }
 
 fn ensure_directory(path: impl AsRef<Path>) -> Result<(), ContainerError> {
     let path = path.as_ref();
     if !path.exists() {
-        create_dir_all(path)?;
+        create_dir_all(path).context(FsErrSnafu)?;
     }
     Ok(())
 }
@@ -351,31 +355,15 @@ fn add_mount<T: AsRef<Path>>(
         flags,
         Option::<&str>::None,
     )
-    .map_err(|err| ContainerError::Mount {
+    .with_context(|_| MountSnafu {
         target: target.to_owned(),
-        err,
     })?;
     Ok(())
 }
 
-fn set_current_dir(path: impl AsRef<Path>) -> io::Result<()> {
-    #[derive(Debug, Error)]
-    #[error("failed to set current directory to `{}`", path.display())]
-    struct SetCurrentDirError {
-        source: io::Error,
-        path: PathBuf,
-    }
-
+fn set_current_dir(path: impl AsRef<Path>) -> Result<(), ContainerError> {
     let path = path.as_ref();
-    std::env::set_current_dir(path).map_err(|source| {
-        io::Error::new(
-            source.kind(),
-            SetCurrentDirError {
-                source,
-                path: path.to_owned(),
-            },
-        )
-    })
+    std::env::set_current_dir(path).with_context(|_| SetCurrentDirSnafu { path: path.to_owned() })
 }
 
 fn ignore_sigint() -> Result<(), nix::Error> {
@@ -451,48 +439,47 @@ struct Bind {
     read_only: bool,
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Snafu)]
 pub enum Error {
-    #[error("exited with failure: {0}")]
-    Failure(String),
-    #[error("stopped by signal: {}", .0.as_str())]
-    Signaled(Signal),
-    #[error("unknown exit reason")]
+    #[snafu(display("exited with failure: {message}"))]
+    Failure { message: String },
+    #[snafu(display("stopped by signal: {signal}"))]
+    Signaled { signal: Signal },
+    #[snafu(display("unknown exit reason"))]
     UnknownExit,
-    #[error("error setting up rootless id map")]
-    Idmap(#[from] idmap::Error),
-    #[error("nix")]
-    Nix(#[from] nix::Error),
-    #[error("io")]
-    Io(#[from] io::Error),
+    #[snafu(display("error setting up rootless id map"))]
+    Idmap { source: idmap::Error },
+    // FIXME: Replace with more fine-grained variants
+    #[snafu(display("nix"))]
+    Nix { source: nix::Error },
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Snafu)]
 enum ContainerError {
-    #[error(transparent)]
-    Run(Box<dyn std::error::Error + Send + Sync>),
-    #[error("io")]
-    Io(#[from] io::Error),
-
-    // Errors from linux system functions
-    #[error("set_pdeathsig")]
-    SetPDeathSig(#[source] nix::Error),
-    #[error("wait for continue message")]
-    ReadContinueMsg(#[source] nix::Error),
-    #[error("close read end of pipe")]
-    CloseReadFd(#[source] nix::Error),
-    #[error("sethostname")]
-    SetHostname(#[source] nix::Error),
-    #[error("pivot_root")]
-    PivotRoot(#[source] nix::Error),
-    #[error("unmount old root")]
-    UnmountOldRoot(#[source] nix::Error),
-    #[error("mount {}", target.display())]
-    Mount {
-        target: PathBuf,
-        #[source]
-        err: nix::Error,
+    #[snafu(display("run"))]
+    Run {
+        source: Box<dyn std::error::Error + Send + Sync>,
     },
+    #[snafu(display("set current dir"))]
+    SetCurrentDirError { path: PathBuf, source: io::Error },
+    #[snafu(display("setup localhost"))]
+    SetupLocalhost { source: io::Error },
+    #[snafu(display("set_pdeathsig"))]
+    SetPDeathSig { source: nix::Error },
+    #[snafu(display("wait for continue message"))]
+    ReadContinueMsg { source: nix::Error },
+    #[snafu(display("close read end of pipe"))]
+    CloseReadFd { source: nix::Error },
+    #[snafu(display("sethostname"))]
+    SetHostname { source: nix::Error },
+    #[snafu(display("pivot_root"))]
+    PivotRoot { source: nix::Error },
+    #[snafu(display("unmount old root"))]
+    UnmountOldRoot { source: nix::Error },
+    #[snafu(display("mount {}", target.display()))]
+    Mount { target: PathBuf, source: nix::Error },
+    #[snafu(display("filesystem"))]
+    FsErr { source: io::Error },
 }
 
 #[repr(u8)]

--- a/crates/container/src/lib.rs
+++ b/crates/container/src/lib.rs
@@ -113,7 +113,7 @@ impl Container {
     /// Run `f` as a container process payload
     pub fn run<E>(self, mut f: impl FnMut() -> Result<(), E>) -> Result<(), Error>
     where
-        E: std::error::Error + 'static,
+        E: std::error::Error + Send + Sync + 'static,
     {
         static mut STACK: [u8; 4 * 1024 * 1024] = [0u8; 4 * 1024 * 1024];
 
@@ -212,7 +212,7 @@ impl Container {
 /// Reenter the container
 fn enter<E>(container: &Container, sync: (i32, i32), mut f: impl FnMut() -> Result<(), E>) -> Result<(), ContainerError>
 where
-    E: std::error::Error + 'static,
+    E: std::error::Error + Send + Sync + 'static,
 {
     // Ensure process is cleaned up if parent dies
     set_pdeathsig(Signal::SIGKILL).map_err(ContainerError::SetPDeathSig)?;
@@ -470,7 +470,7 @@ pub enum Error {
 #[derive(Debug, Error)]
 enum ContainerError {
     #[error(transparent)]
-    Run(Box<dyn std::error::Error>),
+    Run(Box<dyn std::error::Error + Send + Sync>),
     #[error("io")]
     Io(#[from] io::Error),
 


### PR DESCRIPTION
If we decide to go this path, we should probably convert all of the crates.

This forces us to be much more explicit about error propagation and adding any relevant context, but makes that very convenient.