### PR TITLE
boulder: Numerous toolchain changes

### DIFF
--- a/boulder/data/macros/actions/cargo.yaml
+++ b/boulder/data/macros/actions/cargo.yaml
@@ -14,14 +14,14 @@ actions:
         command: |
             cargo fetch -v --locked
         dependencies:
-            - rust
+            - binary(cargo)
 
     - cargo_build:
         description: Build the rust project
         command: |
             cargo build %(options_cargo_release)
         dependencies:
-            - rust
+            - binary(cargo)
 
     - cargo_install:
         description: Install the built binary
@@ -37,14 +37,14 @@ actions:
             }
             cargo_install
         dependencies:
-            - rust
+            - binary(cargo)
 
     - cargo_test:
         description: Run tests
         command: |
             cargo test %(options_cargo_release) --workspace
         dependencies:
-            - rust
+            - binary(cargo)
 
 definitions:
     # The default cargo build profile

--- a/boulder/data/macros/actions/cmake.yaml
+++ b/boulder/data/macros/actions/cmake.yaml
@@ -5,36 +5,36 @@ actions:
         command: |
             cmake %(options_cmake)
         dependencies:
-            - cmake
+            - binary(cmake)
 
     - cmake_unity:
         description: Perform cmake with unity build enabled
         command: |
             cmake -DCMAKE_UNITY_BUILD=ON %(options_cmake)
         dependencies:
-            - cmake
+            - binary(cmake)
 
     - cmake_build:
         description: Build the cmake project
         command: |
             ninja -v -j "%(jobs)" -C "%(builddir)"
         dependencies:
-            - ninja
+            - binary(ninja)
 
     - cmake_install:
         description: Install results of the build to the destination directory
         command: |
             DESTDIR="%(installroot)" ninja install -v -j "%(jobs)" -C "%(builddir)"
         dependencies:
-            - ninja
+            - binary(ninja)
 
     - cmake_test:
         description: Run testsuite with ctest
         command: |
             ninja test -v -j "%(jobs)" -C "%(builddir)"
         dependencies:
-            - cmake
-            - ninja
+            - binary(cmake)
+            - binary(ninja)
 
 definitions:
 

--- a/boulder/data/macros/actions/meson.yaml
+++ b/boulder/data/macros/actions/meson.yaml
@@ -6,9 +6,9 @@ actions:
             test -e ./meson.build || ( echo "%%meson: The ./meson.build script could not be found" ; exit 1 )
             CFLAGS="${CFLAGS}" CXXFLAGS="${CXXFLAGS}" LDFLAGS="${LDFLAGS}" meson setup %(options_meson)
         dependencies:
-            - cmake
-            - meson
-            - pkgconf
+            - binary(cmake)
+            - binary(meson)
+            - binary(pkgconf)
 
     - meson_unity:
         description: Run meson with unity build enabled
@@ -16,30 +16,30 @@ actions:
             test -e ./meson.build || ( echo "%%meson: The ./meson.build script could not be found" ; exit 1 )
             CFLAGS="${CFLAGS}" CXXFLAGS="${CXXFLAGS}" LDFLAGS="${LDFLAGS}" meson setup --unity on %(options_meson)
         dependencies:
-            - cmake
-            - meson
-            - pkgconf
+            - binary(cmake)
+            - binary(meson)
+            - binary(pkgconf)
 
     - meson_build:
         description: Build the meson project
         command: |
             meson compile -v -j "%(jobs)" -C "%(builddir)"
         dependencies:
-            - meson
+            - binary(meson)
 
     - meson_install:
         description: Install results of the build to the destination directory
         command: |
             DESTDIR="%(installroot)" meson install --no-rebuild -C "%(builddir)"
         dependencies:
-            - meson
+            - binary(meson)
 
     - meson_test:
         description: Run meson test
         command: |
             meson test --no-rebuild --print-errorlogs -j "%(jobs)" -C "%(builddir)"
         dependencies:
-            - meson
+            - binary(meson)
 
 definitions:
 

--- a/boulder/data/macros/actions/misc.yaml
+++ b/boulder/data/macros/actions/misc.yaml
@@ -47,7 +47,7 @@ actions:
         command: |
             patch -f -p1 -i
         dependencies:
-            - patch
+            - binary(patch)
 
     - tmpfiles:
         description: Create a tmpfiles.d file for the package with given content

--- a/boulder/data/macros/actions/perl.yaml
+++ b/boulder/data/macros/actions/perl.yaml
@@ -8,5 +8,5 @@ actions:
         command: |
             perl Makefile.PL PREFIX="%(prefix)" NO_PACKLIST=1 NO_PERLLOCAL=1 INSTALLDIRS=vendor DESTDIR="%(installroot)"
         dependencies:
-            - perl
+            - binary(perl)
 

--- a/boulder/data/macros/actions/pgo.yaml
+++ b/boulder/data/macros/actions/pgo.yaml
@@ -42,7 +42,7 @@ actions:
             }
             boptim
         dependencies:
-            - llvm-bolt
+            - binary(llvm-bolt)
 
     - bolt_perf:
         description: Collect perf data suitable for the bolt macros
@@ -53,7 +53,7 @@ actions:
             }
             bperf
         dependencies:
-            - perf
+            - binary(perf)
 
     - bolt_perf2bolt:
         description: Convert perf data into bolt equivalent

--- a/boulder/data/macros/actions/python.yaml
+++ b/boulder/data/macros/actions/python.yaml
@@ -6,14 +6,14 @@ actions:
             test -e ./setup.py || ( echo "%%python: The ./setup.py script could not be found" ; exit 1 )
             python3 setup.py build
         dependencies:
-            - python
+            - binary(python3)
 
     - python_install:
         description: Install python package to the destination directory
         command: |
             python3 setup.py install --root="%(installroot)"
         dependencies:
-            - python
+            - binary(python3)
             - python-packaging # auto deps handler
 
     - pyproject_build:
@@ -21,7 +21,7 @@ actions:
         command: |
             python3 -m build --wheel --no-isolation
         dependencies:
-            - python
+            - binary(python3)
             - python-build
             - python-wheel
 
@@ -30,7 +30,7 @@ actions:
         command: |
             python3 -m installer --destdir="%(installroot)" dist/*.whl
         dependencies:
-            - python
+            - binary(python3)
             - python-installer
 
     # TODO: Investigate whether providing additional -opt1.pyc and -opt2.pyc from increasing
@@ -41,11 +41,11 @@ actions:
         command: |
             function python_compile() {
                 if [ -z "$1" ]; then
-                    python -m compileall -q %(installroot) || exit 1
+                    python3 -m compileall -q %(installroot) || exit 1
                 else
-                    python -m compileall -q $* || exit 1
+                    python3 -m compileall -q $* || exit 1
                 fi
             }
             python_compile
         dependencies:
-            - python
+            - binary(python3)

--- a/boulder/data/macros/arch/base.yaml
+++ b/boulder/data/macros/arch/base.yaml
@@ -101,6 +101,7 @@ defaultTuningGroups :
     - avxwidth
     - base
     - bindnow
+    - build-id
     - debug
     - fortify
     - frame-pointer
@@ -135,6 +136,11 @@ tuning              :
     - frame-pointer:
         enabled: no-omit-frame-pointer
         disabled: omit-frame-pointer
+
+    # Toggle build-id
+    - build-id:
+        enabled: build-id
+        disabled: build-id-none
 
     # Enable bindnow functionality
     - bindnow:
@@ -419,6 +425,16 @@ flags               :
         llvm:
             c         : "-fwhole-program-vtables"
             cxx       : "-fwhole-program-vtables"
+
+    # Enable build-id (ON)
+    - build-id:
+        ld        : "-Wl,--build-id=sha1"
+        rust      : "-C link-args=-Wl,--build-id=sha1"
+
+    # Disable build-id (OFF)
+    - build-id-none:
+        ld        : "-Wl,--build-id=none"
+        rust      : "-C link-args=-Wl,--build-id=none"
 
     # Enable ALL LLVM ICF optimisations (OFF)
     - icf-all:

--- a/boulder/data/macros/arch/base.yaml
+++ b/boulder/data/macros/arch/base.yaml
@@ -108,6 +108,7 @@ defaultTuningGroups :
     - frame-pointer
     - harden
     - icf
+    - lto
     - lto-errors
     - optimize
     - relr
@@ -197,7 +198,7 @@ tuning              :
                 enabled: lto-full
             - thin:
                 enabled: lto-thin
-        default: full
+        default: thin
 
     # Enable LTOextra. Requires the equivalent lto option
     - ltoextra:
@@ -206,7 +207,7 @@ tuning              :
                 enabled: ltoextra-full
             - thin:
                 enabled: ltoextra-thin
-        default: full
+        default: thin
 
     # Enable LTO errors
     - lto-errors:
@@ -413,7 +414,7 @@ flags               :
             d         : "-flto=full"
             ld        : "-flto=full"
 
-    # Enable Thin-LTO optimisations (OFF)
+    # Enable Thin-LTO optimisations (ON)
     - lto-thin:
         rust      : "-C lto=thin -C linker-plugin-lto -C embed-bitcode=yes"
         gnu:

--- a/boulder/data/macros/arch/base.yaml
+++ b/boulder/data/macros/arch/base.yaml
@@ -530,8 +530,8 @@ flags               :
     # Toggle options you want to use with llvm-bolt (OFF)
     - bolt:
         gnu:
-            c         : "-fno-reorder-blocks-and-partition​"
-            cxx       : "-fno-reorder-blocks-and-partition​"
+            c         : "-fno-reorder-blocks-and-partition"
+            cxx       : "-fno-reorder-blocks-and-partition"
             ld        : "-Wl,-q"
         llvm:
             c         : "-fno-split-machine-functions"

--- a/boulder/data/macros/arch/base.yaml
+++ b/boulder/data/macros/arch/base.yaml
@@ -103,6 +103,7 @@ defaultTuningGroups :
     - bindnow
     - build-id
     - debug
+    - fat-lto
     - fortify
     - frame-pointer
     - harden
@@ -205,6 +206,11 @@ tuning              :
             - thin:
                 enabled: ltoextra-thin
         default: full
+
+    # Toggle fat LTO objects
+    - fat-lto:
+        enabled: fat-lto
+        disabled: fat-lto-none
 
     # Enable ICF
     - icf:
@@ -429,6 +435,16 @@ flags               :
         llvm:
             c         : "-fwhole-program-vtables"
             cxx       : "-fwhole-program-vtables"
+
+    # Enable Fat LTO Objects. Note that this is only necessary when building static objects with LLVM that are used in a GCC build (ON)
+    - fat-lto:
+        c         : "-ffat-lto-objects"
+        cxx       : "-ffat-lto-objects"
+
+    # Disable Fat LTO Objects (OFF)
+    - fat-lto-none:
+        c         : "-fno-fat-lto-objects"
+        cxx       : "-fno-fat-lto-objects"
 
     # Enable build-id (ON)
     - build-id:

--- a/boulder/data/macros/arch/base.yaml
+++ b/boulder/data/macros/arch/base.yaml
@@ -108,6 +108,7 @@ defaultTuningGroups :
     - frame-pointer
     - harden
     - icf
+    - lto-errors
     - optimize
     - relr
     - symbolic
@@ -206,6 +207,10 @@ tuning              :
             - thin:
                 enabled: ltoextra-thin
         default: full
+
+    # Enable LTO errors
+    - lto-errors:
+        enabled: lto-errors
 
     # Toggle fat LTO objects
     - fat-lto:
@@ -445,6 +450,15 @@ flags               :
     - fat-lto-none:
         c         : "-fno-fat-lto-objects"
         cxx       : "-fno-fat-lto-objects"
+
+    # Toggle LTO warning errors. If these throw an error it is likely that there will be runtime problems with LTO (ON)
+    - lto-errors:
+        gnu:
+            c         : "-Werror=odr -Werror=lto-type-mismatch -Werror=strict-aliasing"
+            cxx       : "-Werror=odr -Werror=lto-type-mismatch -Werror=strict-aliasing"
+        llvm:
+            c         : "-Werror=odr -Werror=strict-aliasing"
+            cxx       : "-Werror=odr -Werror=strict-aliasing"
 
     # Enable build-id (ON)
     - build-id:

--- a/boulder/data/macros/arch/base.yaml
+++ b/boulder/data/macros/arch/base.yaml
@@ -102,6 +102,7 @@ defaultTuningGroups :
     - base
     - bindnow
     - build-id
+    - compress-debug
     - debug
     - fat-lto
     - fortify
@@ -134,6 +135,18 @@ tuning              :
             - std:
                 enabled: debug-std
         default: std
+
+    # Debug symbol compression
+    - compress-debug:
+        options:
+            - none:
+                enabled: compress-debug-none
+            - zlib:
+                enabled: compress-debug-zlib
+            - zstd:
+                enabled: compress-debug-zstd
+        disabled: compress-debug-none
+        default: zstd
 
     # Toggle frame-pointer
     - frame-pointer:
@@ -470,6 +483,27 @@ flags               :
     - build-id-none:
         ld        : "-Wl,--build-id=none"
         rust      : "-C link-args=-Wl,--build-id=none"
+
+    # Compress debug symbols with Zstd (ON)
+    - compress-debug-zstd:
+        c         : "-Wa,--compress-debug-sections=zstd"
+        cxx       : "-Wa,--compress-debug-sections=zstd"
+        ld        : "-Wl,--compress-debug-sections=zstd"
+        rust      : "-C link-args=-Wl,--compress-debug-sections=zstd"
+
+    # Compress debug symbols with zlib (OFF)
+    - compress-debug-zlib:
+        c         : "-Wa,--compress-debug-sections=zlib"
+        cxx       : "-Wa,--compress-debug-sections=zlib"
+        ld        : "-Wl,--compress-debug-sections=zlib"
+        rust      : "-C link-args=-Wl,--compress-debug-sections=zlib"
+
+    # Don't compress debug symbols (OFF)
+    - compress-debug-none:
+        c         : "-Wa,--compress-debug-sections=none"
+        cxx       : "-Wa,--compress-debug-sections=none"
+        ld        : "-Wl,--compress-debug-sections=none"
+        rust      : "-C link-args=-Wl,--compress-debug-sections=none"
 
     # Enable ALL LLVM ICF optimisations (OFF)
     - icf-all:

--- a/boulder/data/macros/arch/base.yaml
+++ b/boulder/data/macros/arch/base.yaml
@@ -393,18 +393,22 @@ flags               :
     - lto-full:
         rust      : "-C lto=fat -C linker-plugin-lto -C embed-bitcode=yes"
         gnu:
-            c         : "-flto=%(jobs)"
-            cxx       : "-flto=%(jobs)"
-            ld        : "-flto=%(jobs)"
+            c         : "-flto=%(jobs) -flto-partition=one"
+            cxx       : "-flto=%(jobs) -flto-partition=one"
+            ld        : "-flto=%(jobs) -flto-partition=one"
         llvm:
-            c         : "-flto"
-            cxx       : "-flto"
+            c         : "-flto=full"
+            cxx       : "-flto=full"
             d         : "-flto=full"
-            ld        : "-flto"
+            ld        : "-flto=full"
 
     # Enable Thin-LTO optimisations (OFF)
     - lto-thin:
         rust      : "-C lto=thin -C linker-plugin-lto -C embed-bitcode=yes"
+        gnu:
+            c         : "-flto=%(jobs)"
+            cxx       : "-flto=%(jobs)"
+            ld        : "-flto=%(jobs)"
         llvm:
             c         : "-flto=thin"
             cxx       : "-flto=thin"

--- a/boulder/src/build/root.rs
+++ b/boulder/src/build/root.rs
@@ -103,6 +103,10 @@ fn packages(builder: &Builder) -> Vec<&str> {
         }
     }
 
+    if builder.recipe.parsed.mold {
+        packages.extend(MOLD_PACKAGES);
+    }
+
     if builder.ccache {
         packages.extend(CCACHE_PACKAGES);
     }
@@ -202,6 +206,8 @@ const GNU32_PACKAGES: &[&str] = &["gcc-32bit", "g++-32bit"];
 
 const LLVM_PACKAGES: &[&str] = &["clang"];
 const LLVM32_PACKAGES: &[&str] = &["clang-32bit", "libcxx-32bit-devel"];
+
+const MOLD_PACKAGES: &[&str] = &["binary(mold)"];
 
 const CCACHE_PACKAGES: &[&str] = &["binary(ccache)", "binary(sccache)"];
 

--- a/crates/stone_recipe/src/lib.rs
+++ b/crates/stone_recipe/src/lib.rs
@@ -48,6 +48,8 @@ pub struct Recipe {
     pub tuning: Vec<KeyValue<Tuning>>,
     #[serde(default, deserialize_with = "stringy_bool")]
     pub emul32: bool,
+    #[serde(default, deserialize_with = "stringy_bool")]
+    pub mold: bool,
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Note: I bundled these together because most of them are pretty small and I worked on all of them at the same time, but I can split them out if needed (they're separate commits per-change).

Changes:
- Add build-id flags and enable it by default
- Default to compressing debug symbols with zstd. This reduces on-disk space of debug symbols significantly at the cost of higher package sizes.
- Define `-flto=%(jobs)` for GCC as "thin" LTO since it behaves roughly similar to the LLVM equivalent. Add `-flto=%(jobs) -flto-partition=one` as a new "full" variant of LTO for GCC.
- Add `-ffat-lto-objects` flags and enable them by default. These are needed if building static archives with LTO that are used by the alternate toolchain (IE if the static archives are built with GCC then fat-lto-objects is needed in order to link them with LLVM). Interestingly this also reduced binary sizes with LTO over not having the flag, likely because more information was preserved to the linker.
- Add some error flags recommended by Gentoo which can provide an early warning that LTO is likely to result in runtime issues. Enable by default.
- Enable thin LTO by default. Several other distros have switched to this as the default by now and it's better to deal with the fallout of it _now_ rather than when we have a few thousand extra packages.
- Add direct support for mold including automatically adding it as a builddep and setting the appropriate error flags
- Changed many dependencies added by macros to be `binary(*)` dependencies instead of named ones.

Testing:
- Did many, many builds between LLVM/GCC/Mold with the new flags in order to ensure that they worked everywhere as expected.