### PR TITLE
Enable a few allow-by-default clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,23 @@ semicolon_in_expressions_from_macros = "warn"
 unused_import_braces = "warn"
 unused_qualifications = "warn"
 
+[workspace.lints.clippy]
+branches_sharing_code = "warn"
+cloned_instead_of_copied = "warn"
+disallowed_types = "warn"
+empty_line_after_outer_attr = "warn"
+inefficient_to_string = "warn"
+macro_use_imports = "warn"
+map_flatten = "warn"
+missing_enforced_import_renames = "warn"
+mut_mut = "warn"
+nonstandard_macro_braces = "warn"
+semicolon_if_nothing_returned = "warn"
+str_to_string = "warn"
+uninlined_format_args = "warn"
+unreadable_literal = "warn"
+wildcard_imports = "warn"
+
 [profile.release]
 lto = "thin"
 

--- a/boulder/src/build.rs
+++ b/boulder/src/build.rs
@@ -193,9 +193,8 @@ impl Builder {
                                     .unwrap_or_default();
 
                                 println!(
-                                    "\n{}{} {}",
+                                    "\n{}{line_num} {}",
                                     "Breakpoint".bold(),
-                                    line_num,
                                     if breakpoint.exit {
                                         "(exit)".dim()
                                     } else {
@@ -274,7 +273,7 @@ impl Builder {
 pub fn build_target_prefix(target: BuildTarget, i: usize) -> String {
     let newline = if i > 0 { "\n".into() } else { String::default() };
 
-    format!("{}{}", newline, target.to_string().dim())
+    format!("{newline}{}", target.to_string().dim())
 }
 
 pub fn pgo_stage_prefix(stage: pgo::Stage, i: usize) -> String {
@@ -284,14 +283,14 @@ pub fn pgo_stage_prefix(stage: pgo::Stage, i: usize) -> String {
         String::default()
     };
 
-    format!("{}{}", newline, format!("│pgo-{stage}").dim())
+    format!("{newline}{}", format!("│pgo-{stage}").dim())
 }
 
 pub fn phase_prefix(phase: job::Phase, is_pgo: bool, i: usize) -> String {
     let pipes = if is_pgo { "││".dim() } else { "│".dim() };
     let newline = if i > 0 { format!("{pipes}\n") } else { String::default() };
 
-    format!("{}{pipes}{}", newline, phase.styled(phase))
+    format!("{newline}{pipes}{}", phase.styled(phase))
 }
 
 fn logged(

--- a/boulder/src/build/job.rs
+++ b/boulder/src/build/job.rs
@@ -78,7 +78,7 @@ fn work_dir(build_dir: &Path, upstreams: &[Upstream]) -> PathBuf {
                 let unpack_dir = unpack_dir
                     .as_ref()
                     .map(|dir| dir.display().to_string())
-                    .unwrap_or_else(|| rename.to_string());
+                    .unwrap_or_else(|| rename.to_owned());
 
                 work_dir = build_dir.join(unpack_dir);
             }
@@ -87,7 +87,7 @@ fn work_dir(build_dir: &Path, upstreams: &[Upstream]) -> PathBuf {
                 let target = clone_dir
                     .as_ref()
                     .map(|dir| dir.display().to_string())
-                    .unwrap_or_else(|| source.to_string());
+                    .unwrap_or_else(|| source.to_owned());
 
                 work_dir = build_dir.join(target);
             }

--- a/boulder/src/build/job/phase.rs
+++ b/boulder/src/build/job/phase.rs
@@ -112,7 +112,7 @@ impl Phase {
             .or(root_build.environment.as_deref())
             .filter(|env| *env != "(null)" && !env.is_empty() && !matches!(self, Phase::Prepare))
             .unwrap_or_default()
-            .to_string();
+            .to_owned();
         env = format!("%scriptBase\n{env}\n");
 
         let mut parser = script::Parser::new().env(env);
@@ -131,7 +131,7 @@ impl Phase {
                 .arch
                 .get(arch)
                 .cloned()
-                .ok_or_else(|| Error::MissingArchMacros(arch.to_string()))?;
+                .ok_or_else(|| Error::MissingArchMacros(arch.to_owned()))?;
 
             parser.add_macros(macros.clone());
         }
@@ -183,7 +183,6 @@ impl Phase {
             parser.add_definition("compiler_nm", "llvm-nm");
             parser.add_definition("compiler_ranlib", "llvm-ranlib");
             parser.add_definition("compiler_strip", "llvm-strip");
-            parser.add_definition("compiler_path", path);
         } else {
             parser.add_definition("compiler_c", "gcc");
             parser.add_definition("compiler_cxx", "g++");
@@ -199,8 +198,8 @@ impl Phase {
             parser.add_definition("compiler_nm", "gcc-nm");
             parser.add_definition("compiler_ranlib", "gcc-ranlib");
             parser.add_definition("compiler_strip", "strip");
-            parser.add_definition("compiler_path", path);
         }
+        parser.add_definition("compiler_path", path);
 
         /* Allow packagers to do stage specific actions in a pgo build */
         if matches!(pgo_stage, Some(pgo::Stage::One)) {
@@ -244,7 +243,7 @@ fn prepare_script(upstreams: &[stone_recipe::Upstream]) -> String {
                 let unpack_dir = unpack_dir
                     .as_ref()
                     .map(|dir| dir.display().to_string())
-                    .unwrap_or_else(|| rename.to_string());
+                    .unwrap_or_else(|| rename.to_owned());
                 let strip_dirs = strip_dirs.unwrap_or(1);
 
                 let _ = writeln!(&mut content, "mkdir -p {unpack_dir}");
@@ -265,7 +264,7 @@ fn prepare_script(upstreams: &[stone_recipe::Upstream]) -> String {
                 let target = clone_dir
                     .as_ref()
                     .map(|dir| dir.display().to_string())
-                    .unwrap_or_else(|| source.to_string());
+                    .unwrap_or_else(|| source.to_owned());
 
                 let _ = writeln!(&mut content, "mkdir -p {target}");
                 let _ = writeln!(
@@ -295,7 +294,7 @@ fn add_tuning(
             .arch
             .get(arch)
             .cloned()
-            .ok_or_else(|| Error::MissingArchMacros(arch.to_string()))?;
+            .ok_or_else(|| Error::MissingArchMacros(arch.to_owned()))?;
 
         tuning.add_macros(macros);
     }

--- a/boulder/src/build/upstream.rs
+++ b/boulder/src/build/upstream.rs
@@ -63,7 +63,7 @@ pub fn sync(recipe: &Recipe, paths: &Paths) -> Result<(), Error> {
 
                 let install = upstream.fetch(paths, &pb).await?;
 
-                pb.set_message(format!("{} {}", "Copying".yellow(), upstream.name().bold(),));
+                pb.set_message(format!("{} {}", "Copying".yellow(), upstream.name().bold()));
                 pb.set_style(
                     ProgressStyle::with_template(" {spinner} {wide_msg} ")
                         .unwrap()
@@ -84,7 +84,7 @@ pub fn sync(recipe: &Recipe, paths: &Paths) -> Result<(), Error> {
 
                 pb.finish();
                 mp.remove(&pb);
-                mp.suspend(|| println!("{} {}{}", "Shared".green(), upstream.name().bold(), cached_tag,));
+                mp.suspend(|| println!("{} {}{cached_tag}", "Shared".green(), upstream.name().bold()));
                 tp.inc(1);
 
                 Ok(()) as Result<_, Error>
@@ -187,10 +187,10 @@ impl FromStr for Hash {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s.len() < 5 {
-            return Err(ParseHashError::TooShort(s.to_string()));
+            return Err(ParseHashError::TooShort(s.to_owned()));
         }
 
-        Ok(Self(s.to_string()))
+        Ok(Self(s.to_owned()))
     }
 }
 
@@ -258,7 +258,7 @@ impl Plain {
 
         if path.exists() {
             return Ok(Installed::Plain {
-                name: name.to_string(),
+                name: name.to_owned(),
                 path,
                 was_cached: true,
             });
@@ -284,7 +284,7 @@ impl Plain {
             fs::remove_file(&partial_path).await?;
 
             return Err(Error::HashMismatch {
-                name: name.to_string(),
+                name: name.to_owned(),
                 expected: self.hash.0.clone(),
                 got: hash,
             });
@@ -293,7 +293,7 @@ impl Plain {
         fs::rename(partial_path, &path).await?;
 
         Ok(Installed::Plain {
-            name: name.to_string(),
+            name: name.to_owned(),
             path,
             was_cached: false,
         })
@@ -358,7 +358,7 @@ impl Git {
         if self.ref_exists(&final_path).await? {
             self.reset_to_ref(&final_path).await?;
             return Ok(Installed::Git {
-                name: self.name().to_string(),
+                name: self.name().to_owned(),
                 path: final_path,
                 was_cached: true,
             });
@@ -385,7 +385,7 @@ impl Git {
         self.reset_to_ref(&final_path).await?;
 
         Ok(Installed::Git {
-            name: self.name().to_string(),
+            name: self.name().to_owned(),
             path: final_path,
             was_cached: false,
         })

--- a/boulder/src/cli.rs
+++ b/boulder/src/cli.rs
@@ -145,7 +145,7 @@ fn replace_aliases(args: std::env::Args) -> Vec<String> {
             continue;
         }
 
-        args.splice(pos..pos + 1, replacements.iter().map(|arg| arg.to_string()));
+        args.splice(pos..pos + 1, replacements.iter().map(|&arg| arg.to_owned()));
 
         break;
     }

--- a/boulder/src/cli/build.rs
+++ b/boulder/src/cli/build.rs
@@ -96,7 +96,7 @@ pub fn handle(command: Command, env: Env) -> Result<(), Error> {
     let _fd = inhibit(
         vec!["shutdown", "sleep", "idle", "handle-lid-switch"],
         "boulder".into(),
-        format!("Build in-progress: {}", pkg_name),
+        format!("Build in-progress: {pkg_name}"),
         "block".into(),
     );
 

--- a/boulder/src/cli/profile.rs
+++ b/boulder/src/cli/profile.rs
@@ -102,7 +102,7 @@ pub fn list(manager: profile::Manager<'_>) -> Result<(), Error> {
             .iter()
             .sorted_by(|(_, a), (_, b)| a.priority.cmp(&b.priority).reverse())
         {
-            println!(" - {} = {} [{}]", id, repo.uri, repo.priority);
+            println!(" - {id} = {} [{}]", repo.uri, repo.priority);
         }
     }
 

--- a/boulder/src/cli/profile.rs
+++ b/boulder/src/cli/profile.rs
@@ -52,7 +52,7 @@ fn parse_repository(s: &str) -> Result<(repository::Id, Repository), String> {
         .filter_map(|kv| kv.split_once('='))
         .collect::<BTreeMap<_, _>>();
 
-    let id = repository::Id::new(key_values.get("name").ok_or("missing name")?.to_string());
+    let id = repository::Id::new(key_values.get("name").ok_or("missing name")?);
     let uri = key_values
         .get("uri")
         .ok_or("missing uri")?
@@ -115,7 +115,7 @@ pub fn add<'a>(
     name: String,
     repos: Vec<(repository::Id, Repository)>,
 ) -> Result<(), Error> {
-    let id = profile::Id::new(name);
+    let id = profile::Id::new(&name);
 
     manager.save_profile(
         id.clone(),

--- a/boulder/src/cli/recipe.rs
+++ b/boulder/src/cli/recipe.rs
@@ -104,7 +104,7 @@ pub enum Upstream {
 
 fn parse_upstream(s: &str) -> Result<Upstream, String> {
     match s.strip_prefix("git|") {
-        Some(rev) => Ok(Upstream::Git(rev.to_string())),
+        Some(rev) => Ok(Upstream::Git(rev.to_owned())),
         None => Ok(Upstream::Plain(s.parse::<Url>().map_err(|e| e.to_string())?)),
     }
 }
@@ -142,11 +142,9 @@ fn bump(recipe: PathBuf, release: Option<u64>) -> Result<(), Error> {
 
     fs::write(&recipe, updated.as_bytes()).map_err(Error::Write)?;
     println!(
-        "{}: {} release updated from {} to {}",
+        "{}: {} release updated from {prev} to {next}",
         recipe.display(),
         parsed.source.name,
-        prev,
-        next
     );
 
     Ok(())
@@ -228,7 +226,7 @@ fn update(
                     .and_then(|map| map.keys().next())
                     .cloned();
                 if let Some(key) = key {
-                    updates.push(Update::GitUpstream(i, key, new_ref))
+                    updates.push(Update::GitUpstream(i, key, new_ref));
                 }
             }
         }
@@ -278,7 +276,7 @@ fn update(
     if overwrite {
         let recipe = recipe.expect("checked above");
         fs::write(&recipe, updated.as_bytes()).map_err(Error::Write)?;
-        println!("{} updated", recipe.display())
+        println!("{} updated", recipe.display());
     } else {
         print!("{updated}");
     }
@@ -289,7 +287,7 @@ fn update(
 async fn fetch_hash(uri: Url, mpb: &MultiProgress) -> Result<String, Error> {
     let pb = mpb.add(
         ProgressBar::new(u64::MAX)
-            .with_message(format!("{} {}", "Fetching".blue(), uri.to_string().bold(),))
+            .with_message(format!("{} {}", "Fetching".blue(), uri.to_string().bold()))
             .with_style(
                 ProgressStyle::with_template(" {spinner} {wide_msg} {binary_bytes_per_sec:>.dim} ")
                     .unwrap()

--- a/boulder/src/cli/version.rs
+++ b/boulder/src/cli/version.rs
@@ -17,9 +17,9 @@ pub struct Command {
 
 pub fn handle(command: Command) {
     if command.full {
-        print_full()
+        print_full();
     } else {
-        print()
+        print();
     }
 }
 

--- a/boulder/src/draft/build/autotools.rs
+++ b/boulder/src/draft/build/autotools.rs
@@ -48,7 +48,7 @@ fn scan_autotools(state: &mut State<'_>, path: &Path) -> Result<(), Error> {
     // Check all meson dependency() calls
     for captures in regex_pkgconfig.captures_iter(&contents) {
         if let Some(capture) = captures.get(2) {
-            let name = capture.as_str().to_string();
+            let name = capture.as_str().to_owned();
 
             state.add_dependency(Dependency {
                 kind: dependency::Kind::PkgConfig,

--- a/boulder/src/draft/build/meson.rs
+++ b/boulder/src/draft/build/meson.rs
@@ -43,7 +43,7 @@ fn scan_meson(state: &mut State<'_>, path: &Path) -> Result<(), Error> {
     // Check all meson dependency() calls
     for captures in regex_dependency.captures_iter(&contents) {
         if let Some(capture) = captures.get(1) {
-            let name = capture.as_str().to_string();
+            let name = capture.as_str().to_owned();
 
             state.add_dependency(Dependency {
                 kind: dependency::Kind::PkgConfig,
@@ -55,7 +55,7 @@ fn scan_meson(state: &mut State<'_>, path: &Path) -> Result<(), Error> {
     // Check all meson find_program() calls
     for captures in regex_program.captures_iter(&contents) {
         if let Some(capture) = captures.get(1) {
-            let name = capture.as_str().to_string();
+            let name = capture.as_str().to_owned();
 
             // Relative programs are a no go
             if name.contains('/') {

--- a/boulder/src/draft/metadata/basic.rs
+++ b/boulder/src/draft/metadata/basic.rs
@@ -15,14 +15,14 @@ pub fn source(upstream: &Url) -> Option<Source> {
     let regex = Regex::new(r"^([a-zA-Z0-9-]+)-([a-zA-Z0-9._-]+)\.(zip|tar|sh|bin\.*)").ok()?;
     let captures = regex.captures(filename)?;
 
-    let name = captures.get(1)?.as_str().to_string();
-    let version = captures.get(2)?.as_str().to_string();
+    let name = captures.get(1)?.as_str().to_owned();
+    let version = captures.get(2)?.as_str().to_owned();
 
     let (homepage, _) = upstream.as_str().rsplit_once('/')?;
 
     Some(Source {
         name,
         version,
-        homepage: homepage.to_string(),
+        homepage: homepage.to_owned(),
     })
 }

--- a/boulder/src/draft/metadata/github.rs
+++ b/boulder/src/draft/metadata/github.rs
@@ -24,7 +24,7 @@ pub fn source(upstream: &Url) -> Option<Source> {
 
         let owner = captures.get(1)?.as_str();
         let project = captures.get(2)?.as_str();
-        let version = captures.get(3)?.as_str().to_string();
+        let version = captures.get(3)?.as_str().to_owned();
 
         return Some(Source {
             name: project.to_lowercase(),

--- a/boulder/src/package.rs
+++ b/boulder/src/package.rs
@@ -41,7 +41,7 @@ impl<'a> Packager<'a> {
         // Arch names used to parse [`Macros`] for package templates
         //
         // We always use "base" plus whatever build targets we've built
-        let arches = Some("base".to_string())
+        let arches = Some("base".to_owned())
             .into_iter()
             .chain(targets.iter().map(|target| target.build_target.to_string()));
 

--- a/boulder/src/package/analysis.rs
+++ b/boulder/src/package/analysis.rs
@@ -99,7 +99,7 @@ impl<'a> Chain<'a> {
                                 "│ ×".yellow(),
                                 format!("{}", path.target_path.display()).dim(),
                                 format!("({reason})").yellow()
-                            )
+                            );
                         });
                         pb.inc(1);
                         continue 'paths;

--- a/boulder/src/package/analysis/handler.rs
+++ b/boulder/src/package/analysis/handler.rs
@@ -45,13 +45,13 @@ pub fn binary(bucket: &mut BucketMut<'_>, info: &mut PathInfo) -> Result<Respons
     if info.target_path.starts_with("/usr/bin") {
         let provider = Provider {
             kind: dependency::Kind::Binary,
-            name: info.file_name().to_string(),
+            name: info.file_name().to_owned(),
         };
         bucket.providers.insert(provider);
     } else if info.target_path.starts_with("/usr/sbin") {
         let provider = Provider {
             kind: dependency::Kind::SystemBinary,
-            name: info.file_name().to_string(),
+            name: info.file_name().to_owned(),
         };
         bucket.providers.insert(provider);
     }
@@ -75,7 +75,7 @@ pub fn pkg_config(bucket: &mut BucketMut<'_>, info: &mut PathInfo) -> Result<Res
         } else {
             dependency::Kind::PkgConfig
         },
-        name: provider_name.to_string(),
+        name: provider_name.to_owned(),
     };
 
     bucket.providers.insert(provider);
@@ -114,7 +114,7 @@ pub fn pkg_config(bucket: &mut BucketMut<'_>, info: &mut PathInfo) -> Result<Res
 
         bucket.dependencies.insert(Dependency {
             kind,
-            name: dep.to_string(),
+            name: dep.to_owned(),
         });
     }
 
@@ -153,7 +153,7 @@ pub fn python(bucket: &mut BucketMut<'_>, info: &mut PathInfo) -> Result<Respons
     /* Insert versioned provider for auto deps */
     bucket.providers.insert(Provider {
         kind: dependency::Kind::Python,
-        name: format!("{}({})", python_name, &python_version.to_string().trim_end()),
+        name: format!("{python_name}({})", &python_version.to_string().trim_end()),
     });
 
     /* Now parse dependencies */
@@ -197,7 +197,7 @@ pub fn cmake(bucket: &mut BucketMut<'_>, info: &mut PathInfo) -> Result<Response
 
     bucket.providers.insert(Provider {
         kind: dependency::Kind::CMake,
-        name: provider_name.to_string(),
+        name: provider_name.to_owned(),
     });
 
     Ok(Decision::NextHandler.into())

--- a/boulder/src/package/collect.rs
+++ b/boulder/src/package/collect.rs
@@ -78,7 +78,7 @@ impl Collector {
             .matching_package(target_path.to_str().unwrap_or_default())
             .ok_or(Error::NoMatchingRule)?;
 
-        PathInfo::new(path, target_path, metadata, hasher, package.to_string())
+        PathInfo::new(path, target_path, metadata, hasher, package.to_owned())
     }
 
     /// Enumerates all paths from the filesystem starting at root or subdir of root, if provided

--- a/boulder/src/package/emit.rs
+++ b/boulder/src/package/emit.rs
@@ -60,7 +60,7 @@ impl<'a> Package<'a> {
 
     pub fn meta(&self) -> Meta {
         Meta {
-            name: self.name.to_string().into(),
+            name: self.name.to_owned().into(),
             version_identifier: self.source.version.clone(),
             source_release: self.source.release,
             build_release: self.build_release.get(),

--- a/boulder/src/package/emit/manifest/json.rs
+++ b/boulder/src/package/emit/manifest/json.rs
@@ -24,7 +24,7 @@ pub fn write(
     let packages = packages
         .iter()
         .map(|package| {
-            let name = package.name.to_string();
+            let name = package.name.to_owned();
 
             let build_depends = build_deps.iter().cloned().collect();
             let mut depends = package
@@ -59,7 +59,7 @@ pub fn write(
         .collect();
 
     let content = Content {
-        manifest_version: "0.2".to_string(),
+        manifest_version: "0.2".to_owned(),
         packages,
         source_name: recipe.parsed.source.name.clone(),
         source_release: recipe.parsed.source.release.to_string(),

--- a/boulder/src/profile.rs
+++ b/boulder/src/profile.rs
@@ -19,7 +19,7 @@ use crate::Env;
 pub struct Id(String);
 
 impl Id {
-    pub fn new(identifier: String) -> Self {
+    pub fn new(identifier: &str) -> Self {
         Self(
             identifier
                 .chars()
@@ -31,7 +31,7 @@ impl Id {
 
 impl From<String> for Id {
     fn from(value: String) -> Self {
-        Self::new(value)
+        Self::new(&value)
     }
 }
 

--- a/boulder/src/recipe.rs
+++ b/boulder/src/recipe.rs
@@ -43,19 +43,14 @@ impl Recipe {
         let host = architecture::host();
         let host_string = host.to_string();
 
+        let mut targets = vec![];
         if self.parsed.architectures.is_empty() {
-            let mut targets = vec![];
-
             if self.parsed.emul32 {
                 targets.push(BuildTarget::Emul32(host));
             }
 
             targets.push(BuildTarget::Native(host));
-
-            targets
         } else {
-            let mut targets = vec![];
-
             let emul32 = BuildTarget::Emul32(host);
             let emul32_string = emul32.to_string();
 
@@ -69,9 +64,9 @@ impl Recipe {
             {
                 targets.push(BuildTarget::Native(host));
             }
-
-            targets
         }
+
+        targets
     }
 
     pub fn build_target_profile_key(&self, target: BuildTarget) -> Option<String> {
@@ -80,7 +75,7 @@ impl Recipe {
         if self.parsed.profiles.iter().any(|kv| kv.key == target_string) {
             Some(target_string)
         } else if target.emul32() && self.parsed.profiles.iter().any(|kv| &kv.key == "emul32") {
-            Some("emul32".to_string())
+            Some("emul32".to_owned())
         } else {
             None
         }

--- a/boulder/src/timing.rs
+++ b/boulder/src/timing.rs
@@ -118,11 +118,11 @@ impl Timing {
         );
 
         for (target, stages) in &self.build {
-            println!("│{}", build::build_target_prefix(*target, 0),);
+            println!("│{}", build::build_target_prefix(*target, 0));
 
             for (stage, phases) in stages {
                 if let Some(stage) = stage {
-                    println!("│{}", build::pgo_stage_prefix(*stage, 0),);
+                    println!("│{}", build::pgo_stage_prefix(*stage, 0));
                 }
 
                 for (phase, entry) in phases {

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+allow-mixed-uninlined-format-args = false

--- a/crates/fnmatch/src/lib.rs
+++ b/crates/fnmatch/src/lib.rs
@@ -76,7 +76,7 @@ impl<'a> StringWalker<'a> {
     }
 
     pub fn eat(&mut self, much: usize) {
-        self.index += much
+        self.index += much;
     }
 
     /// Find next occurrence of the character, and substring up to it
@@ -127,7 +127,7 @@ impl Pattern {
                 let kv = self
                     .groups
                     .iter()
-                    .map(|k| (k.clone(), m.name(k).unwrap().as_str().to_string()));
+                    .map(|k| (k.clone(), m.name(k).unwrap().as_str().to_owned()));
                 Some(Match {
                     path: path.into(),
                     variables: kv.collect(),
@@ -197,7 +197,7 @@ fn fragments_from_string(s: &str) -> Result<Vec<Fragment>, Error> {
                 builder.push(Fragment::Text(text.clone()));
                 text.clear();
             }
-            builder.push(token)
+            builder.push(token);
         }
     }
 

--- a/crates/serpent_buildinfo/build.rs
+++ b/crates/serpent_buildinfo/build.rs
@@ -8,8 +8,8 @@ use chrono::{DateTime, Utc};
 /// This also outputs necessary ‘cargo:rerun-if-env-changed’ tag to make sure
 /// build script is rerun if the environment variable changes.
 fn env(key: &str) -> Result<std::ffi::OsString, Box<dyn std::error::Error>> {
-    println!("cargo:rerun-if-env-changed={}", key);
-    std::env::var_os(key).ok_or_else(|| Box::from(format!("Missing `{}` environmental variable", key)))
+    println!("cargo:rerun-if-env-changed={key}");
+    std::env::var_os(key).ok_or_else(|| Box::from(format!("Missing `{key}` environmental variable")))
 }
 
 /// Calls program with given arguments and returns its standard output.  If
@@ -34,9 +34,9 @@ fn command(prog: &str, args: &[&str], cwd: Option<std::path::PathBuf>) -> Result
         }
         Ok(stdout)
     } else if let Some(code) = out.status.code() {
-        Err(Box::from(format!("{}: terminated with {}", prog, code)))
+        Err(Box::from(format!("{prog}: terminated with {code}")))
     } else {
-        Err(Box::from(format!("{}: killed by signal", prog)))
+        Err(Box::from(format!("{prog}: killed by signal")))
     }
 }
 
@@ -57,7 +57,7 @@ fn get_git_info() -> Result<(), Box<dyn std::error::Error>> {
         Err(msg) => {
             // We're not in a git repo, most likely we're building from a source archive
             println!("cargo:warning=unable to determine git version (not in git repository?)");
-            println!("cargo:warning={}", msg);
+            println!("cargo:warning={msg}");
 
             // It's unlikely, but possible that someone could run git init. Might as well catch that.
             println!("cargo::rerun-if-changed={}/.git", pkg_dir.display());
@@ -81,7 +81,7 @@ fn get_git_info() -> Result<(), Box<dyn std::error::Error>> {
         std::borrow::Cow::Borrowed(full_hash) => {
             println!("cargo:rustc-env=BUILDINFO_GIT_FULL_HASH={}", full_hash.trim());
         }
-        std::borrow::Cow::Owned(full_hash) => return Err(Box::from(format!("git: Invalid output: {}", full_hash))),
+        std::borrow::Cow::Owned(full_hash) => return Err(Box::from(format!("git: Invalid output: {full_hash}"))),
     }
 
     // Get the short git hash
@@ -91,7 +91,7 @@ fn get_git_info() -> Result<(), Box<dyn std::error::Error>> {
         std::borrow::Cow::Borrowed(short_hash) => {
             println!("cargo:rustc-env=BUILDINFO_GIT_SHORT_HASH={}", short_hash.trim());
         }
-        std::borrow::Cow::Owned(short_hash) => return Err(Box::from(format!("git: Invalid output: {}", short_hash))),
+        std::borrow::Cow::Owned(short_hash) => return Err(Box::from(format!("git: Invalid output: {short_hash}"))),
     }
 
     // Get whether this is built from a dirty tree
@@ -102,7 +102,7 @@ fn get_git_info() -> Result<(), Box<dyn std::error::Error>> {
             0 => {}
             _ => println!("cargo:rustc-cfg=BUILDINFO_IS_DIRTY"),
         },
-        std::borrow::Cow::Owned(output) => return Err(Box::from(format!("git: Invalid output: {}", output))),
+        std::borrow::Cow::Owned(output) => return Err(Box::from(format!("git: Invalid output: {output}"))),
     }
 
     // Get the commit summary
@@ -112,7 +112,7 @@ fn get_git_info() -> Result<(), Box<dyn std::error::Error>> {
         std::borrow::Cow::Borrowed(summary) => {
             println!("cargo:rustc-env=BUILDINFO_GIT_SUMMARY={}", summary.trim());
         }
-        std::borrow::Cow::Owned(summary) => return Err(Box::from(format!("git: Invalid output: {}", summary))),
+        std::borrow::Cow::Owned(summary) => return Err(Box::from(format!("git: Invalid output: {summary}"))),
     }
 
     Ok(())

--- a/crates/serpent_buildinfo/src/lib.rs
+++ b/crates/serpent_buildinfo/src/lib.rs
@@ -24,7 +24,7 @@ pub fn get_build_time() -> String {
             return build_time.to_rfc3339();
         }
     }
-    "unknown".to_string()
+    "unknown".to_owned()
 }
 
 /// Returns `true` if the project was built from a git source, `false` otherwise
@@ -100,9 +100,9 @@ pub fn get_simple_version() -> String {
     let git = if cfg!(BUILDINFO_IS_GIT_BUILD) {
         format!(" (Git ref {}{})", get_git_full_hash(), get_git_dirty())
     } else {
-        "".to_string()
+        "".to_owned()
     };
-    format!("v{}{}", values::VERSION, git)
+    format!("v{}{git}", values::VERSION)
 }
 
 /// For git builds this returns a string like `v0.1.0 (git 4ecad5d7e70c2cdc81350dc6b46fb55b1ccb18f5-dirty)`
@@ -112,7 +112,7 @@ pub fn get_full_version() -> String {
     let git = if cfg!(BUILDINFO_IS_GIT_BUILD) {
         format!(" (Git ref {}{})", get_git_full_hash(), get_git_dirty())
     } else {
-        "".to_string()
+        "".to_owned()
     };
-    format!("version v{}{} (Built at {})", values::VERSION, git, get_build_time())
+    format!("version v{}{git} (Built at {})", values::VERSION, get_build_time())
 }

--- a/crates/stone/benches/read.rs
+++ b/crates/stone/benches/read.rs
@@ -30,10 +30,10 @@ fn read<R: Read + Seek>(reader: R) {
 
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("read unbuffered", |b| {
-        b.iter(|| read_unbuffered(black_box("../test/bash-completion-2.11-1-1-x86_64.stone")))
+        b.iter(|| read_unbuffered(black_box("../test/bash-completion-2.11-1-1-x86_64.stone")));
     });
     c.bench_function("read buffered", |b| {
-        b.iter(|| read_buffered(black_box("../test/bash-completion-2.11-1-1-x86_64.stone")))
+        b.iter(|| read_buffered(black_box("../test/bash-completion-2.11-1-1-x86_64.stone")));
     });
 }
 

--- a/crates/stone/src/payload/layout.rs
+++ b/crates/stone/src/payload/layout.rs
@@ -104,7 +104,7 @@ impl Record for Layout {
 
         let source_length = reader.read_u16()?;
         let target_length = reader.read_u16()?;
-        let sanitize = |s: String| s.trim_end_matches('\0').to_string();
+        let sanitize = |s: String| s.trim_end_matches('\0').to_owned();
 
         let file_type = match reader.read_u8()? {
             1 => FileType::Regular,

--- a/crates/stone/src/payload/meta.rs
+++ b/crates/stone/src/payload/meta.rs
@@ -183,7 +183,7 @@ impl Record for Meta {
         let _padding = reader.read_array::<1>()?;
 
         // Remove null terminated byte from string
-        let sanitize = |s: String| s.trim_end_matches('\0').to_string();
+        let sanitize = |s: String| s.trim_end_matches('\0').to_owned();
 
         let kind = match kind {
             1 => Kind::Int8(reader.read_u8()? as i8),

--- a/crates/stone/src/write/zstd.rs
+++ b/crates/stone/src/write/zstd.rs
@@ -137,5 +137,5 @@ impl Encoder {
 
 fn map_error_code(code: usize) -> io::Error {
     let msg = zstd_safe::get_error_name(code);
-    io::Error::new(io::ErrorKind::Other, msg.to_string())
+    io::Error::new(io::ErrorKind::Other, msg.to_owned())
 }

--- a/crates/stone_recipe/src/script.rs
+++ b/crates/stone_recipe/src/script.rs
@@ -156,7 +156,7 @@ fn parse(
             env.as_ref().map(|env| format!("{env}\n")).unwrap_or_default()
         )
         .trim()
-        .to_string()
+        .to_owned()
     };
 
     tokens(input, |token| {
@@ -164,7 +164,7 @@ fn parse(
             Token::Action(identifier) => {
                 let action = actions
                     .get(identifier)
-                    .ok_or(Error::UnknownAction(identifier.to_string()))?;
+                    .ok_or(Error::UnknownAction(identifier.to_owned()))?;
                 dependencies.extend(action.dependencies.clone());
 
                 if let Some(nested) = parse_content_only(&action.command, actions, definitions, dependencies)? {
@@ -174,7 +174,7 @@ fn parse(
             Token::Definition(identifier) => {
                 let definition = definitions
                     .get(identifier)
-                    .ok_or(Error::UnknownDefinition(identifier.to_string()))?;
+                    .ok_or(Error::UnknownDefinition(identifier.to_owned()))?;
 
                 if let Some(nested) = parse_content_only(definition, actions, definitions, dependencies)? {
                     content.push_str(&nested);
@@ -183,7 +183,7 @@ fn parse(
             Token::Plain(plain) => content.push_str(plain),
             Token::Newline => {
                 line_num += 1;
-                content.push('\n')
+                content.push('\n');
             }
             Token::Break { exit } => {
                 let content = prepend_env(&std::mem::take(&mut content));
@@ -321,7 +321,7 @@ mod test {
         assert_eq!(
             script.commands,
             vec![
-                Command::Content("patch -v --args=a,b,c %escaped %{".to_string()),
+                Command::Content("patch -v --args=a,b,c %escaped %{".to_owned()),
                 Command::Break(Breakpoint {
                     exit: false,
                     line_num: 2,
@@ -331,11 +331,11 @@ mod test {
                     line_num: 3,
                 }),
                 Command::Content(
-                    "/mason/pkg/0001-deps-analysis-elves-In-absence-of-soname.-make-one-u.patch".to_string()
+                    "/mason/pkg/0001-deps-analysis-elves-In-absence-of-soname.-make-one-u.patch".to_owned()
                 ),
             ]
         );
-        assert_eq!(script.dependencies, vec!["patch".to_string()])
+        assert_eq!(script.dependencies, vec!["patch".to_owned()]);
     }
 
     #[test]

--- a/crates/tui/src/pretty.rs
+++ b/crates/tui/src/pretty.rs
@@ -31,7 +31,7 @@ pub trait ColumnDisplay: Sized {
 }
 
 pub fn print_columns<T: ColumnDisplay>(items: &[T], colnum: usize) {
-    column_printer(items, Some(colnum))
+    column_printer(items, Some(colnum));
 }
 
 /// Prints a vec of items that implement the ColumnDisplay trait.
@@ -39,7 +39,7 @@ pub fn print_columns<T: ColumnDisplay>(items: &[T], colnum: usize) {
 /// These will be printed in individual columns assuming that the input order is
 /// alphabetically sorted, to give each column an ascending alpha sort.
 pub fn autoprint_columns<T: ColumnDisplay>(items: &[T]) {
-    column_printer(items, None)
+    column_printer(items, None);
 }
 
 fn column_printer<T: ColumnDisplay>(items: &[T], colnum: Option<usize>) {

--- a/crates/vfs/src/path.rs
+++ b/crates/vfs/src/path.rs
@@ -1,6 +1,6 @@
 pub fn join(a: &str, b: &str) -> String {
     if b.starts_with('/') {
-        b.to_string()
+        b.to_owned()
     } else if a.ends_with('/') {
         format!("{a}{b}")
     } else {

--- a/crates/vfs/src/tree/builder.rs
+++ b/crates/vfs/src/tree/builder.rs
@@ -55,7 +55,7 @@ impl<T: BlitFile> TreeBuilder<T> {
             for component in path::components(parent) {
                 let full_path = match leading_path {
                     Some(fp) => path::join(&fp, component),
-                    None => component.to_string(),
+                    None => component.to_owned(),
                 };
                 leading_path = Some(full_path.clone());
                 self.implicit_dirs
@@ -191,7 +191,7 @@ mod tests {
             },
             CustomFile {
                 path: "/usr/bin/rnano".into(),
-                kind: Kind::Symlink("nano".to_string()),
+                kind: Kind::Symlink("nano".to_owned()),
                 id: "nano".into(),
             },
             CustomFile {

--- a/crates/vfs/src/tree/mod.rs
+++ b/crates/vfs/src/tree/mod.rs
@@ -113,7 +113,7 @@ impl<T: BlitFile> Tree<T> {
     fn add_child_to_node(&mut self, node_id: NodeId, parent: &str) -> Result<(), Error> {
         let node = self.arena.get(node_id).unwrap();
         let Some(parent_node) = self.map.get(parent) else {
-            return Err(Error::MissingParent(parent.to_string()));
+            return Err(Error::MissingParent(parent.to_owned()));
         };
 
         let others = parent_node
@@ -144,12 +144,11 @@ impl<T: BlitFile> Tree<T> {
                     others.first().unwrap().id.clone()
                 )
             );
-
-            Ok(())
         } else {
             parent_node.append(node_id, &mut self.arena);
-            Ok(())
         }
+
+        Ok(())
     }
 
     pub fn print(&self) {
@@ -178,7 +177,7 @@ impl<T: BlitFile> Tree<T> {
             // Remove descendents
             let children = source.children(&self.arena).collect::<Vec<_>>();
             for child in children.iter() {
-                child.remove_subtree(&mut self.arena)
+                child.remove_subtree(&mut self.arena);
             }
         }
 

--- a/crates/yaml/src/updater.rs
+++ b/crates/yaml/src/updater.rs
@@ -21,7 +21,7 @@ impl Updater {
         self.operations.push(Operation {
             path,
             update: Update::Key(key.to_string()),
-        })
+        });
     }
 
     pub fn update_value(&mut self, value: impl ToString, f: impl FnOnce(Path) -> Path) {
@@ -30,7 +30,7 @@ impl Updater {
         self.operations.push(Operation {
             path,
             update: Update::Value(value.to_string()),
-        })
+        });
     }
 
     pub fn apply(&self, input: impl ToString) -> String {
@@ -66,7 +66,7 @@ impl<'a> ops::Div<&'a str> for Path {
     type Output = Self;
 
     fn div(self, rhs: &'a str) -> Self::Output {
-        Self(self.0.into_iter().chain(Some(Segment::Map(rhs.to_string()))).collect())
+        Self(self.0.into_iter().chain(Some(Segment::Map(rhs.to_owned()))).collect())
     }
 }
 

--- a/moss/src/cli/extract.rs
+++ b/moss/src/cli/extract.rs
@@ -37,7 +37,7 @@ pub fn handle(args: &ArgMatches) -> Result<(), Error> {
     let content_store = PathBuf::from(".stoneStore");
 
     for path in paths {
-        println!("Extract: {:?}", path);
+        println!("Extract: {path:?}");
 
         let rdr = File::open(path).map_err(Error::IO)?;
         let mut reader = stone::read(rdr).map_err(Error::Format)?;
@@ -96,7 +96,7 @@ pub fn handle(args: &ArgMatches) -> Result<(), Error> {
             for layout in &layouts.body {
                 match &layout.entry {
                     layout::Entry::Regular(id, target) => {
-                        let store_path = content_store.join(format!("{:02x}", id));
+                        let store_path = content_store.join(format!("{id:02x}"));
                         let target_disk = extraction_root.join("usr").join(target);
 
                         // drop it into a valid dir

--- a/moss/src/cli/index.rs
+++ b/moss/src/cli/index.rs
@@ -120,7 +120,7 @@ fn get_meta(
 
     let (size, hash) = stat_file(path, &relative_path, &progress)?;
 
-    progress.set_message(format!("{} {}", "Indexing".yellow(), relative_path.clone().bold(),));
+    progress.set_message(format!("{} {}", "Indexing".yellow(), relative_path.clone().bold()));
     progress.set_style(
         ProgressStyle::with_template(" {spinner} {wide_msg}")
             .unwrap()

--- a/moss/src/cli/info.rs
+++ b/moss/src/cli/info.rs
@@ -64,7 +64,7 @@ pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error
 /// Print the title for each metadata section
 fn print_titled(title: &'static str) {
     let display_width = COLUMN_WIDTH - title.len();
-    print!("{}{:width$} ", title.bold(), " ", width = display_width);
+    print!("{}{:display_width$} ", title.bold(), " ");
 }
 
 /// Print paragraph with breaks
@@ -102,9 +102,9 @@ fn print_paragraph(p: &str) {
                     println!("{}", current_line.dim());
                     first_line = false;
                 } else {
-                    println!("{:width$} {}", " ", current_line.dim(), width = COLUMN_WIDTH);
+                    println!("{:COLUMN_WIDTH$} {}", " ", current_line.dim());
                 }
-                current_line = word.to_string();
+                current_line = word.to_owned();
             }
         }
 
@@ -113,7 +113,7 @@ fn print_paragraph(p: &str) {
             if first_line && first_paragraph {
                 println!("{}", current_line.dim());
             } else {
-                println!("{:width$} {}", " ", current_line.dim(), width = COLUMN_WIDTH);
+                println!("{:COLUMN_WIDTH$} {}", " ", current_line.dim());
             }
         }
 
@@ -128,7 +128,7 @@ where
     for (idx, item) in items.into_iter().enumerate() {
         match idx {
             0 => println!("• {}", item.to_string()),
-            _ => println!("{:width$} • {}", " ", item.to_string(), width = COLUMN_WIDTH),
+            _ => println!("{:COLUMN_WIDTH$} • {}", " ", item.to_string()),
         }
     }
 }

--- a/moss/src/cli/inspect.rs
+++ b/moss/src/cli/inspect.rs
@@ -59,23 +59,25 @@ pub fn handle(args: &ArgMatches) -> Result<(), Error> {
 
                         match &record.kind {
                             meta::Kind::Provider(k, p) if record.tag == meta::Tag::Provides => {
-                                provs.push(format!("{}({})", k, p))
+                                provs.push(format!("{k}({p})"));
                             }
                             meta::Kind::Provider(k, p) if record.tag == meta::Tag::Conflicts => {
-                                cnfls.push(format!("{}({})", k, p))
+                                cnfls.push(format!("{k}({p})"));
                             }
-                            meta::Kind::Dependency(k, d) => deps.push(format!("{}({})", k, d)),
+                            meta::Kind::Dependency(k, d) => {
+                                deps.push(format!("{k}({d})"));
+                            }
                             meta::Kind::String(s) => {
-                                println!("{:width$} : {}", name, s, width = COLUMN_WIDTH)
+                                println!("{name:COLUMN_WIDTH$} : {s}");
                             }
                             meta::Kind::Int64(i) => {
-                                println!("{:width$} : {}", name, i, width = COLUMN_WIDTH)
+                                println!("{name:COLUMN_WIDTH$} : {i}");
                             }
                             meta::Kind::Uint64(i) => {
-                                println!("{:width$} : {}", name, i, width = COLUMN_WIDTH)
+                                println!("{name:COLUMN_WIDTH$} : {i}");
                             }
                             _ => {
-                                println!("{:width$} : {:?}", name, record, width = COLUMN_WIDTH)
+                                println!("{name:COLUMN_WIDTH$} : {record:?}");
                             }
                         }
                     }
@@ -84,36 +86,36 @@ pub fn handle(args: &ArgMatches) -> Result<(), Error> {
             }
 
             if !deps.is_empty() {
-                println!("\n{:width$} :", "Dependencies", width = COLUMN_WIDTH);
+                println!("\n{:COLUMN_WIDTH$} :", "Dependencies");
                 for dep in deps {
                     println!("    - {dep}");
                 }
             }
             if !provs.is_empty() {
-                println!("\n{:width$} :", "Providers", width = COLUMN_WIDTH);
+                println!("\n{:COLUMN_WIDTH$} :", "Providers");
                 for prov in provs {
                     println!("    - {prov}");
                 }
             }
             if !cnfls.is_empty() {
-                println!("\n{:width$} :", "Conflicts", width = COLUMN_WIDTH);
+                println!("\n{:COLUMN_WIDTH$} :", "Conflicts");
                 for cnfl in cnfls {
                     println!("    - {cnfl}");
                 }
             }
 
             if !layouts.is_empty() {
-                println!("\n{:width$} :", "Layout entries", width = COLUMN_WIDTH);
+                println!("\n{:COLUMN_WIDTH$} :", "Layout entries");
                 for layout in layouts {
                     match layout.entry {
                         layout::Entry::Regular(hash, target) => {
-                            println!("    - /usr/{} - [Regular] {:032x}", target, hash)
+                            println!("    - /usr/{target} - [Regular] {hash:032x}");
                         }
                         layout::Entry::Directory(target) => {
-                            println!("    - /usr/{} [Directory]", target)
+                            println!("    - /usr/{target} [Directory]");
                         }
                         layout::Entry::Symlink(source, target) => {
-                            println!("    - /usr/{} -> {} [Symlink]", target, source)
+                            println!("    - /usr/{target} -> {source} [Symlink]");
                         }
                         _ => unreachable!(),
                     };

--- a/moss/src/cli/list.rs
+++ b/moss/src/cli/list.rs
@@ -137,7 +137,7 @@ pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error
         } else {
             item.name.dim()
         };
-        print!("{} {:width$} ", name, " ", width = width);
+        print!("{name} {:width$} ", " ");
 
         let print_revision = |rev: Revision, is_sync| {
             let version = if is_sync {
@@ -145,7 +145,7 @@ pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error
             } else {
                 rev.version.magenta()
             };
-            print!("{}-{}", version, rev.release.dim());
+            print!("{version}-{}", rev.release.dim());
         };
 
         // Print revision

--- a/moss/src/cli/mod.rs
+++ b/moss/src/cli/mod.rs
@@ -105,18 +105,18 @@ fn generate_manpages(cmd: &Command, dir: &Path, prefix: Option<&str>) -> io::Res
     man.render(&mut buffer)?;
 
     let filename = if let Some(prefix) = prefix {
-        format!("{}-{}.1", prefix, name)
+        format!("{prefix}-{name}.1")
     } else {
-        format!("{}.1", name)
+        format!("{name}.1")
     };
 
     fs::write(dir.join(filename), buffer)?;
 
     for subcmd in cmd.get_subcommands() {
         let new_prefix = if let Some(p) = prefix {
-            format!("{}-{}", p, name)
+            format!("{p}-{name}")
         } else {
-            name.to_string()
+            name.to_owned()
         };
         generate_manpages(subcmd, dir, Some(&new_prefix))?;
     }
@@ -217,7 +217,7 @@ fn replace_aliases(args: env::Args) -> Vec<String> {
             continue;
         };
 
-        args.splice(pos..pos + 1, replacements.iter().map(|arg| arg.to_string()));
+        args.splice(pos..pos + 1, replacements.iter().map(|&arg| arg.to_owned()));
 
         break;
     }

--- a/moss/src/cli/remove.rs
+++ b/moss/src/cli/remove.rs
@@ -57,7 +57,7 @@ pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error
     // Bail if there's packages not installed
     // TODO: Add error hookups
     if !not_installed.is_empty() {
-        println!("Missing packages in lookup: {:?}", not_installed);
+        println!("Missing packages in lookup: {not_installed:?}");
         return Err(Error::NoSuchPackage);
     }
 
@@ -94,7 +94,7 @@ pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error
 
     // Print each package to stdout
     for package in removed {
-        println!("{} {}", "Removed".red(), package.meta.name.to_string().bold(),);
+        println!("{} {}", "Removed".red(), package.meta.name.to_string().bold());
     }
 
     // Map finalized state to a [`Selection`] by referencing

--- a/moss/src/cli/repo.rs
+++ b/moss/src/cli/repo.rs
@@ -166,7 +166,7 @@ fn list(installation: Installation, config: config::Manager) -> Result<(), Error
             String::new()
         };
 
-        println!(" - {} = {} [{}]{}", id, repo.uri, repo.priority, disabled);
+        println!(" - {id} = {} [{}]{disabled}", repo.uri, repo.priority);
     }
 
     Ok(())

--- a/moss/src/cli/repo.rs
+++ b/moss/src/cli/repo.rs
@@ -130,7 +130,7 @@ fn add(
 ) -> Result<(), Error> {
     let mut manager = repository::Manager::system(config, installation)?;
 
-    let id = repository::Id::new(name);
+    let id = repository::Id::new(&name);
 
     manager.add_repository(
         id.clone(),
@@ -178,7 +178,7 @@ fn update(installation: Installation, config: config::Manager, which: Option<Str
 
     runtime::block_on(async {
         match which {
-            Some(repo) => manager.refresh(&repository::Id::new(repo)).await,
+            Some(repo) => manager.refresh(&repository::Id::new(&repo)).await,
             None => manager.refresh_all().await,
         }
     })?;
@@ -188,7 +188,7 @@ fn update(installation: Installation, config: config::Manager, which: Option<Str
 
 /// Remove repo
 fn remove(installation: Installation, config: config::Manager, repo: String) -> Result<(), Error> {
-    let id = repository::Id::new(repo);
+    let id = repository::Id::new(&repo);
 
     let mut manager = repository::Manager::system(config, installation)?;
 
@@ -212,7 +212,7 @@ fn remove(installation: Installation, config: config::Manager, repo: String) -> 
 }
 
 fn enable(installation: Installation, config: config::Manager, repo: String) -> Result<(), Error> {
-    let id = repository::Id::new(repo);
+    let id = repository::Id::new(&repo);
     let mut manager = repository::Manager::system(config, installation)?;
 
     runtime::block_on(manager.enable(&id))?;
@@ -223,7 +223,7 @@ fn enable(installation: Installation, config: config::Manager, repo: String) -> 
 }
 
 fn disable(installation: Installation, config: config::Manager, repo: String) -> Result<(), Error> {
-    let id = repository::Id::new(repo);
+    let id = repository::Id::new(&repo);
     let mut manager = repository::Manager::system(config, installation)?;
 
     runtime::block_on(manager.disable(&id))?;

--- a/moss/src/cli/state.rs
+++ b/moss/src/cli/state.rs
@@ -150,9 +150,9 @@ fn print_state(state: state::State) {
         state.id.to_string().bold(),
         state.summary.unwrap_or_else(|| String::from("system transaction"))
     );
-    println!("{} {}", "Created:".bold(), formatted_time);
+    println!("{} {formatted_time}", "Created:".bold());
     if let Some(desc) = &state.description {
-        println!("{} {}", "Description:".bold(), desc);
+        println!("{} {desc}", "Description:".bold());
     }
     println!("{} {}", "Packages:".bold(), state.selections.len());
     println!();

--- a/moss/src/cli/version.rs
+++ b/moss/src/cli/version.rs
@@ -14,9 +14,9 @@ pub fn command() -> Command {
 pub fn handle(args: &ArgMatches) {
     let show_full = args.get_flag("full");
     if show_full {
-        print_full()
+        print_full();
     } else {
-        print()
+        print();
     }
 }
 

--- a/moss/src/client/boot.rs
+++ b/moss/src/client/boot.rs
@@ -150,7 +150,7 @@ pub fn synchronize(install: &Installation, state: &State, layouts: &[(Id, Layout
             Entry::new(d)
                 .with_cmdline(CmdlineEntry {
                     name: "---fstx---".to_owned(),
-                    snippet: format!("moss.fstx={}", id),
+                    snippet: format!("moss.fstx={id}"),
                 })
                 .with_state_id(id)
         })

--- a/moss/src/client/cache.rs
+++ b/moss/src/client/cache.rs
@@ -268,7 +268,7 @@ fn check_assets_exist(indices: &[&payload::Index], installation: &Installation) 
 /// Returns a fully qualified filesystem path to download the given hash ID into
 pub fn download_path(installation: &Installation, hash: &str) -> Result<PathBuf, Error> {
     if hash.len() < 5 {
-        return Err(Error::MalformedHash(hash.to_string()));
+        return Err(Error::MalformedHash(hash.to_owned()));
     }
 
     let directory = installation

--- a/moss/src/client/install.rs
+++ b/moss/src/client/install.rs
@@ -137,7 +137,7 @@ fn resolve_input(pkgs: &[&str], client: &Client) -> Result<Vec<package::Id>, Err
 
     for (id, pkg) in queried {
         if let Some(pkg) = pkg {
-            results.push(pkg.id)
+            results.push(pkg.id);
         } else {
             return Err(Error::NoPackage(id));
         }

--- a/moss/src/client/mod.rs
+++ b/moss/src/client/mod.rs
@@ -170,7 +170,7 @@ impl Client {
         // Reload manager if not explicit to pickup config changes
         // then refresh indexes
         if !self.repositories.is_explicit() {
-            self.repositories = repository::Manager::system(self.config.clone(), self.installation.clone())?
+            self.repositories = repository::Manager::system(self.config.clone(), self.installation.clone())?;
         };
         self.repositories.refresh_all().await?;
 
@@ -504,7 +504,7 @@ impl Client {
                     let package_name = package.meta.name.to_string();
 
                     // Set progress to unpacking
-                    progress_bar.set_message(format!("{} {}", "Unpacking".yellow(), package_name.clone().bold(),));
+                    progress_bar.set_message(format!("{} {}", "Unpacking".yellow(), package_name.clone().bold()));
                     progress_bar.set_length(1000);
                     progress_bar.set_position(0);
 
@@ -527,7 +527,7 @@ impl Client {
 
                     // Write installed line
                     multi_progress
-                        .suspend(|| println!("{} {}{}", "Installed".green(), package_name.clone().bold(), cached_tag,));
+                        .suspend(|| println!("{} {}{cached_tag}", "Installed".green(), package_name.clone().bold()));
 
                     // Inc total progress by 1
                     total_progress.inc(1);
@@ -696,7 +696,7 @@ impl Client {
     fn blit_element_item(&self, parent: RawFd, cache: RawFd, subpath: &str, item: &PendingFile) -> Result<(), Error> {
         match &item.layout.entry {
             layout::Entry::Regular(id, _) => {
-                let hash = format!("{:02x}", id);
+                let hash = format!("{id:02x}");
                 let directory = if hash.len() >= 10 {
                     PathBuf::from(&hash[..2]).join(&hash[2..4]).join(&hash[4..6])
                 } else {
@@ -709,7 +709,7 @@ impl Client {
                 match *id {
                     // Mystery empty-file hash. Do not allow dupes!
                     // https://github.com/serpent-os/tools/issues/372
-                    0x99aa06d3014798d86001c324468d497f => {
+                    0x99aa_06d3_0147_98d8_6001_c324_468d_497f => {
                         let fd = fcntl::openat(
                             parent,
                             subpath,

--- a/moss/src/client/postblit.rs
+++ b/moss/src/client/postblit.rs
@@ -203,8 +203,8 @@ fn execute_trigger_directly(trigger: &CompiledHandler) -> Result<(), Error> {
                     let stderr = String::from_utf8_lossy(&cmd.stderr);
 
                     eprintln!("Trigger exited with non-zero status code: {run} {args:?}");
-                    eprintln!("   Stdout: {}", stdout);
-                    eprintln!("   Stderr: {}", stderr);
+                    eprintln!("   Stdout: {stdout}");
+                    eprintln!("   Stderr: {stderr}");
                 }
             } else {
                 eprintln!("Failed to execute trigger: {run} {args:?}");

--- a/moss/src/client/prune.rs
+++ b/moss/src/client/prune.rs
@@ -263,12 +263,7 @@ fn remove_orphaned_files(
 fn enumerate_file_hashes(root: impl AsRef<Path>) -> io::Result<BTreeSet<String>> {
     let files = enumerate_files(root)?;
 
-    let path_to_hash = |path: PathBuf| {
-        path.file_name()
-            .and_then(|s| s.to_str())
-            .unwrap_or_default()
-            .to_string()
-    };
+    let path_to_hash = |path: PathBuf| path.file_name().and_then(|s| s.to_str()).unwrap_or_default().to_owned();
 
     Ok(files.into_iter().map(path_to_hash).collect())
 }

--- a/moss/src/db/layout/mod.rs
+++ b/moss/src/db/layout/mod.rs
@@ -52,7 +52,7 @@ impl Database {
                         .load_iter(conn)?
                         .map(map_layout)
                         .collect::<Result<Vec<_>, _>>()?,
-                )
+                );
             }
 
             Ok(output)
@@ -258,7 +258,7 @@ mod test {
             .iter()
             .filter_map(PayloadKind::layout)
             .flat_map(|p| &p.body)
-            .map(|layout| (package::Id::from("test".to_string()), layout))
+            .map(|layout| (package::Id::from("test".to_owned()), layout))
             .collect::<Vec<_>>();
 
         let count = layouts.len();

--- a/moss/src/db/meta/mod.rs
+++ b/moss/src/db/meta/mod.rs
@@ -156,7 +156,7 @@ impl Database {
                     .filter(model::meta::name.eq(name.to_string()))
                     .load_iter::<model::Meta, _>(conn)?,
                 Some(Filter::Keyword(keyword)) => {
-                    let pattern = format!("%{}%", keyword);
+                    let pattern = format!("%{keyword}%");
                     model::meta::table
                         .select(model::Meta::as_select())
                         .filter(
@@ -485,16 +485,16 @@ mod test {
         let meta_payload = payloads.iter().find_map(PayloadKind::meta).unwrap();
         let meta = Meta::from_stone_payload(&meta_payload.body).unwrap();
 
-        let id = package::Id::from("test".to_string());
+        let id = package::Id::from("test".to_owned());
 
         db.add(id.clone(), meta.clone()).unwrap();
 
-        assert_eq!(&meta.name, &"bash-completion".to_string().into());
+        assert_eq!(&meta.name, &"bash-completion".to_owned().into());
 
         // Now retrieve by provider.
         let lookup = Filter::Provider(Provider {
             kind: Kind::PackageName,
-            name: "bash-completion".to_string(),
+            name: "bash-completion".to_owned(),
         });
         let fetched = db.query(Some(lookup)).unwrap();
         assert_eq!(fetched.len(), 1);
@@ -521,7 +521,7 @@ mod test {
         let italian_pizza = include_bytes!("../../../../test/conflicts/italian-pizza-1-1-1-x86_64.stone");
         let pineapple_provider = Provider {
             kind: Kind::PackageName,
-            name: "pineapple".to_string(),
+            name: "pineapple".to_owned(),
         };
 
         let mut stone = stone::read_bytes(italian_pizza).unwrap();
@@ -532,7 +532,7 @@ mod test {
         db.add(package::Id::from(meta.id()), meta.clone()).unwrap();
 
         // Ensure we're parsing the correct package!
-        assert_eq!(&meta.name, &"italian-pizza".to_string().into());
+        assert_eq!(&meta.name, &"italian-pizza".to_owned().into());
         // Ensure that the conflict info already exists in the binary package.
         assert_eq!(
             meta.conflicts.iter().collect::<Vec<&Provider>>(),
@@ -542,7 +542,7 @@ mod test {
         // Now retrieve by provider.
         let lookup = Filter::Provider(Provider {
             kind: Kind::PackageName,
-            name: "italian-pizza".to_string(),
+            name: "italian-pizza".to_owned(),
         });
         let fetched = db.query(Some(lookup)).unwrap();
         assert_eq!(fetched.len(), 1);

--- a/moss/src/db/meta/schema.rs
+++ b/moss/src/db/meta/schema.rs
@@ -51,4 +51,4 @@ diesel::joinable!(meta_dependencies -> meta (package));
 diesel::joinable!(meta_licenses -> meta (package));
 diesel::joinable!(meta_providers -> meta (package));
 
-diesel::allow_tables_to_appear_in_same_query!(meta, meta_conflicts, meta_dependencies, meta_licenses, meta_providers,);
+diesel::allow_tables_to_appear_in_same_query!(meta, meta_conflicts, meta_dependencies, meta_licenses, meta_providers);

--- a/moss/src/db/state/mod.rs
+++ b/moss/src/db/state/mod.rs
@@ -250,9 +250,9 @@ mod test {
         let database = Database::new(":memory:").unwrap();
 
         let selections = vec![
-            Selection::explicit(package::Id::from("pkg a".to_string())),
-            Selection::explicit(package::Id::from("pkg b".to_string())),
-            Selection::explicit(package::Id::from("pkg c".to_string())),
+            Selection::explicit(package::Id::from("pkg a".to_owned())),
+            Selection::explicit(package::Id::from("pkg b".to_owned())),
+            Selection::explicit(package::Id::from("pkg c".to_owned())),
         ];
 
         let state = database.add(&selections, Some("test"), Some("test")).unwrap();

--- a/moss/src/db/state/schema.rs
+++ b/moss/src/db/state/schema.rs
@@ -22,4 +22,4 @@ diesel::table! {
 
 diesel::joinable!(state_selections -> state (state_id));
 
-diesel::allow_tables_to_appear_in_same_query!(state, state_selections,);
+diesel::allow_tables_to_appear_in_same_query!(state, state_selections);

--- a/moss/src/dependency.rs
+++ b/moss/src/dependency.rs
@@ -229,10 +229,10 @@ impl TryFrom<String> for Provider {
 
 /// Parse the [`Kind`] of dependency or provider from the string
 fn parse(s: &str) -> Result<(Kind, String), ParseError> {
-    let (kind, rest) = s.split_once('(').ok_or(ParseError(s.to_string()))?;
+    let (kind, rest) = s.split_once('(').ok_or(ParseError(s.to_owned()))?;
 
     if !rest.ends_with(')') {
-        return Err(ParseError(s.to_string()));
+        return Err(ParseError(s.to_owned()));
     }
 
     let kind = kind.parse::<Kind>().map_err(|e| ParseError(e.to_string()))?;

--- a/moss/src/package/render.rs
+++ b/moss/src/package/render.rs
@@ -21,7 +21,7 @@ impl ColumnDisplay for Package {
     }
 
     fn display_column(&self, writer: &mut impl Write, col: Column, width: usize) {
-        ColumnDisplay::display_column(&self, writer, col, width)
+        ColumnDisplay::display_column(&self, writer, col, width);
     }
 }
 

--- a/moss/src/registry/mod.rs
+++ b/moss/src/registry/mod.rs
@@ -118,9 +118,9 @@ mod test {
         let mut registry = Registry::default();
 
         let package = |id: &str, release| Package {
-            id: package::Id::from(id.to_string()),
+            id: package::Id::from(id.to_owned()),
             meta: package::Meta {
-                name: package::Name::from(id.to_string()),
+                name: package::Name::from(id.to_owned()),
                 version_identifier: Default::default(),
                 source_release: release,
                 build_release: Default::default(),
@@ -156,7 +156,7 @@ mod test {
 
         // Packages are sorted by plugin priority, desc -> release number, desc
         for (idx, package) in query.enumerate() {
-            let id = |id: &str| package::Id::from(id.to_string());
+            let id = |id: &str| package::Id::from(id.to_owned());
 
             match idx {
                 0 => assert_eq!(package.id, id("c")),
@@ -173,9 +173,9 @@ mod test {
         let mut registry = Registry::default();
 
         let package = |id: &str, flags| Package {
-            id: package::Id::from(id.to_string()),
+            id: package::Id::from(id.to_owned()),
             meta: package::Meta {
-                name: package::Name::from(id.to_string()),
+                name: package::Name::from(id.to_owned()),
                 version_identifier: Default::default(),
                 source_release: Default::default(),
                 build_release: Default::default(),
@@ -216,7 +216,7 @@ mod test {
                 .into_iter()
                 .map(|p| String::from(p.meta.name))
                 .collect::<BTreeSet<_>>();
-            let expected = expected.iter().map(|s| s.to_string()).collect::<BTreeSet<_>>();
+            let expected = expected.iter().map(|&s| s.to_owned()).collect::<BTreeSet<_>>();
 
             actual == expected
         }

--- a/moss/src/repository/manager.rs
+++ b/moss/src/repository/manager.rs
@@ -293,7 +293,7 @@ impl Manager {
 
 /// Directory for the repo cached data (db & stone index), hashed by identifier & repo URI
 fn cache_dir(identifier: &str, repo: &Repository, installation: &Installation) -> PathBuf {
-    let hash = format!("{:02x}", xxh3_64(format!("{}-{}", identifier, repo.uri).as_bytes()));
+    let hash = format!("{:02x}", xxh3_64(format!("{identifier}-{}", repo.uri).as_bytes()));
     installation.repo_path(hash)
 }
 

--- a/moss/src/repository/mod.rs
+++ b/moss/src/repository/mod.rs
@@ -27,7 +27,7 @@ pub mod manager;
 pub struct Id(String);
 
 impl Id {
-    pub fn new(identifier: String) -> Self {
+    pub fn new(identifier: &str) -> Self {
         Self(
             identifier
                 .chars()

--- a/moss/src/runtime.rs
+++ b/moss/src/runtime.rs
@@ -39,7 +39,7 @@ pub struct Guard;
 
 impl Drop for Guard {
     fn drop(&mut self) {
-        destroy()
+        destroy();
     }
 }
 

--- a/moss/src/state.rs
+++ b/moss/src/state.rs
@@ -103,6 +103,6 @@ impl pretty::ColumnDisplay for ColumnDisplay<'_> {
     }
 
     fn display_column(&self, writer: &mut impl Write, _col: pretty::Column, width: usize) {
-        let _ = write!(writer, "State {}{:width$}", self.0.id.to_string().bold(), " ",);
+        let _ = write!(writer, "State {}{:width$}", self.0.id.to_string().bold(), " ");
     }
 }


### PR DESCRIPTION
Apart from the first commit, the removal of commas inside formatting macros right before a closing parenthesis on the same line was also done manually (but I was too lazy to split it into its own commit).