### PR TITLE
boulder/draft: Fix a typo python_build -> python_setup

### DIFF
--- a/boulder/src/draft/build/python.rs
+++ b/boulder/src/draft/build/python.rs
@@ -32,7 +32,7 @@ pub mod setup_tools {
     pub fn phases() -> Phases {
         Phases {
             setup: None,
-            build: Some("%python_build"),
+            build: Some("%python_setup"),
             install: Some("%python_install"),
             check: None,
         }


### PR DESCRIPTION
python_build macro dannae exist