### PR TITLE
boulder/draft: Fix github matching

### DIFF
--- a/boulder/src/draft/metadata.rs
+++ b/boulder/src/draft/metadata.rs
@@ -56,5 +56,5 @@ enum Matcher {
 }
 
 impl Matcher {
-    const ALL: &'static [Self] = &[Self::Basic, Self::Github];
+    const ALL: &'static [Self] = &[Self::Github, Self::Basic];
 }


### PR DESCRIPTION
We need to match against "special" providers first before falling back to the default simple case, as it'll break the match on first matcher.