### PR TITLE
boulder/draft: Don't match monitoring on metadata name extract failure

### DIFF
--- a/boulder/src/draft/monitoring.rs
+++ b/boulder/src/draft/monitoring.rs
@@ -57,6 +57,10 @@ impl<'a> Monitoring<'a> {
     }
 
     pub fn run(&self) -> Result<String, Error> {
+        if self.name.is_empty() {
+            return self.format_monitoring(None, vec![], None);
+        }
+
         let client = reqwest::blocking::Client::new();
 
         let id = self.find_monitoring_id(self.name, &client)?;


### PR DESCRIPTION
Just return an empty formatted output